### PR TITLE
Fix for https://github.com/lidatong/dataclasses-json/issues/3

### DIFF
--- a/dataclasses_json/dataclasses_json.py
+++ b/dataclasses_json/dataclasses_json.py
@@ -14,8 +14,13 @@ class _Encoder(json.JSONEncoder):
 class DataClassJsonMixin:
     def to_json(self, *, skipkeys=False, ensure_ascii=True, check_circular=True,
                 allow_nan=True, indent=None, separators=None,
-                default=None, sort_keys=False, **kw):
-        return json.dumps(asdict(self),
+                default=None, sort_keys=False, skip_missing_optionals=False, **kw):
+        dict_ = asdict(self)
+        if skip_missing_optionals:
+            for field in fields(self):
+                if dict_[field.name] is None and _is_optional(field.type):
+                    dict_.pop(field.name)
+        return json.dumps(dict_,
                           cls=_Encoder,
                           skipkeys=skipkeys,
                           ensure_ascii=ensure_ascii,

--- a/dataclasses_json/dataclasses_json.py
+++ b/dataclasses_json/dataclasses_json.py
@@ -77,7 +77,7 @@ def _decode_dataclass(cls, kvs):
         field_value = kvs[field.name]
         if is_dataclass(field.type):
             init_kwargs[field.name] = _decode_dataclass(field.type, field_value)
-        elif _is_supported_generic(field.type) and field.type != str:
+        elif _is_supported_generic(field.type) and field.type != str and field.type.__args__[0] != str:
             init_kwargs[field.name] = _decode_generic(field.type, field_value)
         else:
             init_kwargs[field.name] = field_value

--- a/dataclasses_json/dataclasses_json.py
+++ b/dataclasses_json/dataclasses_json.py
@@ -58,9 +58,17 @@ class DataClassJsonMixin:
                 for init_kwargs in init_kwargs_array]
 
 
+def _is_optional(type_):
+    return (_issubclass_safe(type_, Optional)
+            or _hasargs(type_, type(None)))
+
+
 def _decode_dataclass(cls, kvs):
     init_kwargs = {}
     for field in fields(cls):
+        if field.name not in kvs and _is_optional(field.type):
+            init_kwargs[field.name] = None
+            continue
         field_value = kvs[field.name]
         if is_dataclass(field.type):
             init_kwargs[field.name] = _decode_dataclass(field.type, field_value)
@@ -73,8 +81,7 @@ def _decode_dataclass(cls, kvs):
 
 def _is_supported_generic(type_):
     is_collection = _issubclass_safe(type_, Collection)
-    is_optional = (_issubclass_safe(type_, Optional)
-                   or _hasargs(type_, type(None)))
+    is_optional = _is_optional(type_)
     return is_collection or is_optional
 
 

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -62,6 +62,8 @@ class TestDecoder:
                 DataClassWithOptional(1))
         assert (DataClassWithOptional.from_json('{"x": null}') ==
                 DataClassWithOptional(None))
+        assert (DataClassWithOptional.from_json('{}') ==
+                DataClassWithOptional(None))
 
     def test_custom_list(self):
         print(DataClassWithCustomList.from_json('{"xs": [1]}'))

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -27,6 +27,8 @@ class TestEncoder:
     def test_optional(self):
         assert DataClassWithOptional(1).to_json() == '{"x": 1}'
         assert DataClassWithOptional(None).to_json() == '{"x": null}'
+        assert DataClassWithOptional(1).to_json(skip_missing_optionals=True) == '{"x": 1}'
+        assert DataClassWithOptional(None).to_json(skip_missing_optionals=True) == '{}'
 
     def test_custom_list(self):
         assert (DataClassWithCustomList(CustomList([1])).to_json() ==


### PR DESCRIPTION
This pull request enables possibility to decode json if optional dataclass fields are missing, as well as encoding dataclass to json without optional fields if their values are `None`.
Encoding behavior is controlled by `skip_missing_optionals` keyword argument for `DataClassJsonMixin.to_json()` which defaults to `False` for backwards compatibility.