### PR TITLE
Remove `prefix` from Marshmallow constructor

### DIFF
--- a/dataclasses_json/api.py
+++ b/dataclasses_json/api.py
@@ -65,7 +65,6 @@ class DataClassJsonMixin(abc.ABC):
     def schema(cls,
                only=None,
                exclude=(),
-               prefix='',
                many=False,
                context=None,
                load_only=(),
@@ -86,7 +85,6 @@ class DataClassJsonMixin(abc.ABC):
                                 f'make_{cls.__name__.lower()}': make_instance})
         return DataClassSchema(only=only,
                                exclude=exclude,
-                               prefix=prefix,
                                many=many,
                                context=context,
                                load_only=load_only,

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     keywords="dataclasses json",
     install_requires=[
         "dataclasses;python_version=='3.6'",
-        "marshmallow==3.0.0b13"
+        "marshmallow==3.0.0b18"
     ],
     python_requires=">=3.6",
     extras_require={


### PR DESCRIPTION
This parameter was removed from recent Marshmallow version, and was the reason for the error in #18 .

Removing this parameter should allow upgrading Marshmallow again.