### PR TITLE
Prevent memory leak with repeated calls to .schema()

### DIFF
--- a/dataclasses_json/api.py
+++ b/dataclasses_json/api.py
@@ -102,7 +102,7 @@ class DataClassJsonMixin(abc.ABC):
         def make_instance(self, kvs):
             return _decode_dataclass(cls, kvs, infer_missing=partial)
 
-        DataClassSchema = type(f'{cls.__name__.capitalize()}Schema',
+        DataClassSchema = type('',
                                (Schema,),
                                {'Meta': Meta,
                                 f'make_{cls.__name__.lower()}': make_instance,


### PR DESCRIPTION
When marshmallow Schema classes are instantiated using
`type()`, they get added to marshmallow's internal
[class registry](https://github.com/marshmallow-code/marshmallow/blob/dev/marshmallow/class_registry.py).

To demonstrate:

```python
from marshmallow import class_registry
from dataclasses import dataclass
from dataclasses_json import dataclass_json

@dataclass_json
@dataclass
class Person:
    name: str

lidatong = Person('lidatong')

lidatong.schema()

assert len(class_registry._registry['marshmallow.schema.PersonSchema']) == 1

lidatong.schema()

assert len(class_registry._registry['marshmallow.schema.PersonSchema']) == 2
```

This is a known issue (ref marshmallow-code/marshmallow#732).

Passing a blank name prevents the class from getting
added to the registry.