### PR TITLE
Add support for passing the MM fields directly

### DIFF
--- a/dataclasses_json/api.py
+++ b/dataclasses_json/api.py
@@ -85,11 +85,20 @@ class DataClassJsonMixin(abc.ABC):
             return _decode_dataclass(cls, kvs, infer_missing=partial)
 
         fields_ = fields(cls)
-        nested_fields = mm._make_nested_fields(fields_,
+
+        other_fields = []
+        metadata_fields = {}
+        for f in fields_:
+            if 'mm' in f.metadata:
+                metadata_fields[f.name] = f.metadata['mm']
+            else:
+                other_fields.append(f)
+
+        nested_fields = mm._make_nested_fields(other_fields,
                                                DataClassJsonMixin,
                                                infer_missing)
 
-        primitive_fields = [field for field in fields_
+        primitive_fields = [field for field in other_fields
                             if field.name not in nested_fields]
         default_fields = mm._make_default_fields(primitive_fields,
                                                  cls,
@@ -106,6 +115,7 @@ class DataClassJsonMixin(abc.ABC):
                                (Schema,),
                                {'Meta': Meta,
                                 f'make_{cls.__name__.lower()}': make_instance,
+                                **metadata_fields,
                                 **nested_fields,
                                 **default_fields,
                                 **datetime_fields})

--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -44,7 +44,9 @@ def _decode_dataclass(cls, kvs, infer_missing):
     init_kwargs = {}
     for field in fields(cls):
         field_value = kvs[field.name]
-        if field_value is None and not _is_optional(field.type):
+        if 'mm' in field.metadata:
+            init_kwargs[field.name] = field_value
+        elif field_value is None and not _is_optional(field.type):
             warning = (f"value of non-optional type {field.name} detected "
                        f"when decoding {cls.__name__}")
             if infer_missing:

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,0 +1,34 @@
+import datetime
+from dataclasses import dataclass, field
+
+import pytest
+from marshmallow import fields, ValidationError
+
+from dataclasses_json import DataClassJsonMixin
+
+
+@dataclass
+class Car(DataClassJsonMixin):
+    license_number: str = field(metadata={'mm': fields.String(required=False)})
+
+
+@dataclass
+class StringDate(DataClassJsonMixin):
+    string_date: datetime.datetime = field(metadata={'mm': fields.String(required=False)})
+
+
+car_schema = Car.schema()
+string_date_schema = StringDate.schema()
+
+
+class TestMetadataField:
+
+    def test_validation_error_raises(self):
+        with pytest.raises(ValidationError) as e:
+            car_schema.load({'license_number': 123})
+        assert e.value.messages == {'license_number': ['Not a valid string.']}
+
+    def test_mm_field_takes_precedence_over_types(self):
+        obj = string_date_schema.load({'string_date': 'yesterday'})
+        assert isinstance(obj, StringDate)
+        assert obj.string_date == 'yesterday'


### PR DESCRIPTION
This adds support for passing the Marshmallow fields directly to the dataclass.

This is done via the dataclass field metadata: e.g.:

```python
@dataclass
class Car(DataClassJsonMixin):
    license_number: str = field(metadata={'mm': fields.String(required=False)})
```

The metadata field takes priority over the dataclass type.

I probably forgot a bunch of edge cases, so please review it care 😁 