### PR TITLE
Bug fix for default bool when using schema

### DIFF
--- a/dataclasses_json/mm.py
+++ b/dataclasses_json/mm.py
@@ -109,4 +109,4 @@ def _make_default_field(type_, default, cls):
                             f"instance?")
         arg_cons = _type_to_cons[type_arg]
         return cons(cls, arg_cons, missing=default)
-    return cons(cls, missing=default)
+    return cons(missing=default)

--- a/tests/entities.py
+++ b/tests/entities.py
@@ -106,8 +106,13 @@ class DataClassXs(DataClassJsonMixin):
 
 
 @dataclass(frozen=True)
-class DataClassImmutableDefault(DataClassJsonMixin):
+class DataClassIntImmutableDefault(DataClassJsonMixin):
     x: int = 0
+
+
+@dataclass(frozen=True)
+class DataClassBoolImmutableDefault(DataClassJsonMixin):
+    x: bool = False
 
 
 @dataclass(frozen=True)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,12 +3,12 @@ from uuid import UUID
 
 import pytest
 
-from tests.entities import (DataClassImmutableDefault, DataClassJsonDecorator,
+from tests.entities import (DataClassIntImmutableDefault, DataClassJsonDecorator,
                             DataClassWithDataClass, DataClassWithDatetime,
                             DataClassWithList, DataClassWithOptional,
                             DataClassWithOptionalNested, DataClassWithUuid,
                             DataClassWithIsoDatetime, DataClassWithOverride,
-                            DataClassWithCustomIsoDatetime)
+                            DataClassWithCustomIsoDatetime, DataClassBoolImmutableDefault)
 
 
 class TestTypes:
@@ -147,12 +147,32 @@ class TestSchema:
                 == [DataClassWithDataClass(DataClassWithList([1]))])
 
     def test_loads_default(self):
-        assert (DataClassImmutableDefault.schema().loads('{}')
-                == DataClassImmutableDefault())
+        assert (DataClassIntImmutableDefault.schema().loads('{}')
+                == DataClassIntImmutableDefault())
+        assert (DataClassBoolImmutableDefault.schema().loads('{}')
+                == DataClassBoolImmutableDefault())
 
     def test_loads_default_many(self):
-        assert (DataClassImmutableDefault.schema().loads('[{}]', many=True)
-                == [DataClassImmutableDefault()])
+        assert (DataClassIntImmutableDefault.schema().loads('[{}]', many=True)
+                == [DataClassIntImmutableDefault()])
+        assert (DataClassBoolImmutableDefault.schema().loads('[{}]', many=True)
+                == [DataClassBoolImmutableDefault()])
+
+    def test_dumps_default(self):
+        d_int = DataClassIntImmutableDefault()
+        assert d_int.x == 0
+        assert DataClassIntImmutableDefault.schema().dumps(d_int) == '{"x": 0}'
+        d_bool = DataClassBoolImmutableDefault()
+        assert d_bool.x is False
+        assert DataClassBoolImmutableDefault.schema().dumps(d_bool) == '{"x": false}'
+
+    def test_dumps_default_many(self):
+        d_int = DataClassIntImmutableDefault()
+        assert d_int.x == 0
+        assert DataClassIntImmutableDefault.schema().dumps([d_int], many=True) == '[{"x": 0}]'
+        d_bool = DataClassBoolImmutableDefault()
+        assert d_bool.x is False
+        assert DataClassBoolImmutableDefault.schema().dumps([d_bool], many=True) == '[{"x": false}]'
 
     def test_loads_infer_missing(self):
         assert (DataClassWithOptional

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -1,6 +1,6 @@
 from collections import deque
 
-from tests.entities import (DataClassImmutableDefault,
+from tests.entities import (DataClassIntImmutableDefault,
                             DataClassMutableDefaultDict,
                             DataClassMutableDefaultList, DataClassWithDeque,
                             DataClassWithDict, DataClassWithDictInt,
@@ -54,7 +54,7 @@ class TestEncoder:
             MyCollection([1])).to_json() == '{"xs": [1]}'
 
     def test_immutable_default(self):
-        assert DataClassImmutableDefault().to_json() == '{"x": 0}'
+        assert DataClassIntImmutableDefault().to_json() == '{"x": 0}'
 
     def test_mutable_default_list(self):
         assert DataClassMutableDefaultList().to_json() == '{"xs": []}'
@@ -115,8 +115,8 @@ class TestDecoder:
                 DataClassWithMyCollection(MyCollection([1])))
 
     def test_immutable_default(self):
-        assert (DataClassImmutableDefault.from_json('{"x": 0}')
-                == DataClassImmutableDefault())
+        assert (DataClassIntImmutableDefault.from_json('{"x": 0}')
+                == DataClassIntImmutableDefault())
         assert (DataClassMutableDefaultList.from_json('{}', infer_missing=True)
                 == DataClassMutableDefaultList())
 


### PR DESCRIPTION
This change fixes the issues discussed in #45 where default value boolean fields using marshmallow schema.  Unit tests were added to confirm the problem has been fixed. 