### PR TITLE
Feature add decimal support

### DIFF
--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -30,7 +30,7 @@ class _ExtendedEncoder(json.JSONEncoder):
         elif _isinstance_safe(o, UUID):
             result = str(o)
         elif _isinstance_safe(o, Decimal):
-            result = str(o)
+            result = float(o)
         elif _isinstance_safe(o, Enum):
             result = o.value
         else:

--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 from typing import Collection, Mapping, Union
 from collections import namedtuple
 from uuid import UUID
+from decimal import Decimal
 
 from dataclasses_json.utils import (_get_type_cons, _is_collection, _is_mapping,
                                     _is_optional, _isinstance_safe,
@@ -27,6 +28,8 @@ class _ExtendedEncoder(json.JSONEncoder):
         elif _isinstance_safe(o, datetime):
             result = o.timestamp()
         elif _isinstance_safe(o, UUID):
+            result = str(o)
+        elif _isinstance_safe(o, Decimal):
             result = str(o)
         elif _isinstance_safe(o, Enum):
             result = o.value
@@ -124,6 +127,10 @@ def _decode_dataclass(cls, kvs, infer_missing):
             init_kwargs[field.name] = (field_value
                                        if isinstance(field_value, UUID)
                                        else UUID(field_value))
+        elif _issubclass_safe(field.type, Decimal):
+            init_kwargs[field.name] = (field_value
+                                       if isinstance(field_value, UUID)
+                                       else Decimal(field_value))
         else:
             init_kwargs[field.name] = field_value
     return cls(**init_kwargs)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timezone
 from uuid import UUID
+from decimal import Decimal
 
 import pytest
 
@@ -8,7 +9,8 @@ from tests.entities import (DataClassIntImmutableDefault, DataClassJsonDecorator
                             DataClassWithList, DataClassWithOptional,
                             DataClassWithOptionalNested, DataClassWithUuid,
                             DataClassWithIsoDatetime, DataClassWithOverride,
-                            DataClassWithCustomIsoDatetime, DataClassBoolImmutableDefault)
+                            DataClassWithDecimal, DataClassWithCustomIsoDatetime,
+                            DataClassBoolImmutableDefault)
 
 
 class TestTypes:
@@ -33,6 +35,17 @@ class TestTypes:
     iso = dt.isoformat()
     dc_iso_json = f'{{"created_at": "{iso}"}}'
     dc_iso = DataClassWithIsoDatetime(datetime.fromisoformat(iso))
+
+    dec = Decimal("0.04")
+    dec_ts_json = f'{{"price": "{dec}"}}'
+    print(dec_ts_json)
+    dec_ts = DataClassWithDecimal(dec)
+
+    def test_decimal_encode(self):
+        assert self.dec_ts.to_json() == self.dec_ts_json
+
+    def test_decimal_decode(self):
+        assert DataClassWithDecimal.from_json(self.dec_ts_json) == self.dec_ts
 
     def test_datetime_encode(self):
         assert (self.dc_ts.to_json() == self.dc_ts_json)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -37,15 +37,15 @@ class TestTypes:
     dc_iso = DataClassWithIsoDatetime(datetime.fromisoformat(iso))
 
     dec = Decimal("0.04")
-    dec_ts_json = f'{{"price": "{dec}"}}'
-    print(dec_ts_json)
+    dec_ts_json_in = f'{{"price": "{dec}"}}'
+    dec_ts_json_out = f'{{"price": {dec}}}'
     dec_ts = DataClassWithDecimal(dec)
 
     def test_decimal_encode(self):
-        assert self.dec_ts.to_json() == self.dec_ts_json
+        assert self.dec_ts.to_json() == self.dec_ts_json_out
 
     def test_decimal_decode(self):
-        assert DataClassWithDecimal.from_json(self.dec_ts_json) == self.dec_ts
+        assert DataClassWithDecimal.from_json(self.dec_ts_json_in) == self.dec_ts
 
     def test_datetime_encode(self):
         assert (self.dc_ts.to_json() == self.dc_ts_json)


### PR DESCRIPTION
This adds basic support for decimal type which will by default raise an error when trying to deserialize value back to json (at least for nested dataclasses). Input value should likely be string to maintain precision however it should also work fine with floats/ints in input json.