### PR TITLE
Fix schema problems

### DIFF
--- a/dataclasses_json/api.py
+++ b/dataclasses_json/api.py
@@ -1,13 +1,10 @@
 import abc
 import json
-from dataclasses import fields
-from datetime import datetime
 from typing import Any, Callable, List, Optional, Tuple, TypeVar, Union
 
-from dataclasses_json import mm
+from dataclasses_json.mm import build_schema
 from dataclasses_json.core import (_ExtendedEncoder, _asdict, _decode_dataclass,
-                                   _overrides, _issubclass_safe,
-                                   _override)
+                                   _overrides, _override)
 
 A = TypeVar('A')
 B = TypeVar('B')
@@ -76,7 +73,7 @@ class DataClassJsonMixin(abc.ABC):
                dump_only=(),
                partial=False,
                unknown=None):
-        Schema = mm.build_schema(cls, DataClassJsonMixin, infer_missing, partial)
+        Schema = build_schema(cls, DataClassJsonMixin, infer_missing, partial)
         return Schema(only=only,
                       exclude=exclude,
                       many=many,

--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -60,6 +60,8 @@ def _override(kvs, overrides, attr):
 
 
 def _decode_dataclass(cls, kvs, infer_missing):
+    if isinstance(kvs, cls):
+        return kvs
     overrides = _overrides(cls)
     kvs = {} if kvs is None and infer_missing else kvs
     missing_fields = {field for field in fields(cls) if field.name not in kvs}

--- a/dataclasses_json/mm.py
+++ b/dataclasses_json/mm.py
@@ -102,7 +102,7 @@ def _make_default_field(type_, default, cls):
     cons_type = (type_.__args__[0] if _is_optional(cons_type) else cons_type)
     cons = _type_to_cons[cons_type]
     if cons is fields.List:
-        type_arg = type_.___args__[0]
+        type_arg = type_.__args__[0]
         if type_arg not in _type_to_cons:
             raise TypeError(f"Unsupported {type_arg} detected. Is it "
                             f"a supported JSON type or dataclass_json "

--- a/dataclasses_json/mm.py
+++ b/dataclasses_json/mm.py
@@ -98,8 +98,10 @@ def _make_default_fields(fields_, cls, infer_missing):
 def _make_default_field(type_, default, cls):
     type_ = (type_.__args__[0] if _is_optional(type_) else type_)
     cons_type = type_
-    cons_type = (list if _is_nonstr_collection(cons_type) else cons_type)
-    cons_type = (dict if _is_mapping(cons_type) else cons_type)
+    if _is_mapping(cons_type):
+        cons_type = dict
+    elif _is_nonstr_collection(cons_type):
+        cons_type = list
     cons = _type_to_cons[cons_type]
     if cons is fields.List:
         type_arg = type_.__args__[0]

--- a/dataclasses_json/mm.py
+++ b/dataclasses_json/mm.py
@@ -1,14 +1,16 @@
+import typing
 import warnings
-from dataclasses import MISSING, is_dataclass
+
+from dataclasses import MISSING, is_dataclass, fields as dc_fields
 from datetime import datetime
 from uuid import UUID
 
-from marshmallow import fields
+from marshmallow import fields, Schema, post_load
 
-from dataclasses_json.core import _is_supported_generic
-from dataclasses_json.utils import (_is_collection, _is_mapping,
-                                    _is_nonstr_collection, _is_optional,
+from dataclasses_json.core import _is_supported_generic, _decode_dataclass
+from dataclasses_json.utils import (_is_collection, _is_optional,
                                     _issubclass_safe, _timestamp_to_dt_aware)
+
 
 
 class _TimestampField(fields.Field):
@@ -25,97 +27,6 @@ class _IsoField(fields.Field):
 
     def _deserialize(self, value, attr, data, **kwargs):
         return datetime.fromisoformat(value)
-
-
-_type_to_cons = {
-    dict: fields.Dict,
-    list: fields.List,
-    str: fields.Str,
-    int: fields.Int,
-    float: fields.Float,
-    bool: fields.Bool,
-    datetime: _TimestampField,
-    UUID: fields.UUID
-}
-
-
-def _make_nested_fields(fields_, dataclass_json_cls, infer_missing):
-    nested_fields = {}
-    for field, type_, field_many in _inspect_nested_fields(fields_):
-        if _issubclass_safe(type_, dataclass_json_cls):
-            if infer_missing and _is_optional(field.type):
-                schema = fields.Nested(type_.schema(),
-                                       many=field_many,
-                                       missing=None)
-            else:
-                schema = fields.Nested(type_.schema(),
-                                       many=field_many)
-            nested_fields[field.name] = schema
-        else:
-            warnings.warn(f"Nested dataclass field {field.name} of type "
-                          f"{field.type} detected in "
-                          f"{dataclass_json_cls.__name__} that is not an instance of "
-                          f"dataclass_json. Did you mean to recursively "
-                          f"serialize this field? If so, make sure to "
-                          f"augment {field.type} with either the "
-                          f"`dataclass_json` decorator or mixin.")
-    return nested_fields
-
-
-def _inspect_nested_fields(fields_):
-    nested_dc_fields_and_is_many = []
-    for field in fields_:
-        if _is_supported_generic(field.type):
-            t_arg = field.type.__args__[0]
-            if is_dataclass(t_arg):
-                if _is_collection(field.type):
-                    nested_dc_fields_and_is_many.append((field, t_arg, True))
-                else:
-                    nested_dc_fields_and_is_many.append((field, t_arg, False))
-        elif is_dataclass(field.type):
-            nested_dc_fields_and_is_many.append((field, field.type, False))
-    return nested_dc_fields_and_is_many
-
-
-def _make_default_fields(fields_, cls, infer_missing):
-    default_fields = {}
-    for field in fields_:
-        if field.default is not MISSING:
-            default_fields[field.name] = _make_default_field(field.type,
-                                                             field.default,
-                                                             cls)
-        elif field.default_factory is not MISSING:
-            default_fields[field.name] = _make_default_field(field.type,
-                                                             field.default_factory,
-                                                             cls)
-        elif _is_optional(field.type) and infer_missing:
-            default_fields[field.name] = _make_default_field(field.type,
-                                                             None,
-                                                             cls)
-    return default_fields
-
-
-def _make_default_field(type_, default, cls):
-    cons_type = type_
-    cons_type = (list if _is_nonstr_collection(cons_type) else cons_type)
-    cons_type = (dict if _is_mapping(cons_type) else cons_type)
-    cons_type = (type_.__args__[0] if _is_optional(cons_type) else cons_type)
-    cons = _type_to_cons[cons_type]
-    if cons is fields.List:
-        type_arg = type_.__args__[0]
-        if type_arg not in _type_to_cons:
-            raise TypeError(f"Unsupported {type_arg} detected. Is it "
-                            f"a supported JSON type or dataclass_json "
-                            f"instance?")
-        arg_cons = _type_to_cons[type_arg]
-        return cons(arg_cons, missing=default)
-    return cons(missing=default)
-
-
-import typing
-from dataclasses import fields as dc_fields
-from marshmallow import Schema, post_load
-from dataclasses_json.core import _decode_dataclass
 
 
 TYPES = {

--- a/dataclasses_json/mm.py
+++ b/dataclasses_json/mm.py
@@ -96,20 +96,114 @@ def _make_default_fields(fields_, cls, infer_missing):
 
 
 def _make_default_field(type_, default, cls):
-    type_ = (type_.__args__[0] if _is_optional(type_) else type_)
     cons_type = type_
-    if _is_mapping(cons_type):
-        cons_type = dict
-    elif _is_nonstr_collection(cons_type):
-        cons_type = list
+    cons_type = (list if _is_nonstr_collection(cons_type) else cons_type)
+    cons_type = (dict if _is_mapping(cons_type) else cons_type)
+    cons_type = (type_.__args__[0] if _is_optional(cons_type) else cons_type)
     cons = _type_to_cons[cons_type]
     if cons is fields.List:
         type_arg = type_.__args__[0]
-        if (type_arg not in _type_to_cons
-                and type_arg.__bases__[0].__name__ != 'DataClassJsonMixin'):
+        if type_arg not in _type_to_cons:
             raise TypeError(f"Unsupported {type_arg} detected. Is it "
                             f"a supported JSON type or dataclass_json "
                             f"instance?")
-        arg_cons = _type_to_cons.get(type_arg, fields.Field)
+        arg_cons = _type_to_cons[type_arg]
         return cons(arg_cons, missing=default)
     return cons(missing=default)
+
+
+import typing
+from dataclasses import fields as dc_fields
+from marshmallow import Schema, post_load
+from dataclasses_json.core import _decode_dataclass
+
+
+TYPES = {
+    typing.Mapping: fields.Mapping,
+    typing.MutableMapping: fields.Mapping,
+    typing.List: fields.List,
+    typing.Dict: fields.Dict,
+    typing.Tuple: fields.Tuple,
+    typing.Callable: fields.Function,
+    dict: fields.Dict,
+    list: fields.List,
+    str: fields.Str,
+    int: fields.Int,
+    float: fields.Float,
+    bool: fields.Bool,
+    datetime: _TimestampField,
+    UUID: fields.UUID
+}
+
+def build_type(type_, options, mixin, field, cls):
+    def inner(type_, options):
+        if is_dataclass(type_):
+            if _issubclass_safe(type_, mixin):
+                options['field_many'] = bool(_is_supported_generic(field.type) and _is_collection(field.type))
+                return fields.Nested(type_.schema(), **options)
+            else:
+                warnings.warn(f"Nested dataclass field {field.name} of type "
+                              f"{field.type} detected in "
+                              f"{cls.__name__} that is not an instance of "
+                              f"dataclass_json. Did you mean to recursively "
+                              f"serialize this field? If so, make sure to "
+                              f"augment {type_} with either the "
+                              f"`dataclass_json` decorator or mixin.")
+                return fields.Field(**options)
+
+        origin = getattr(type_, '__origin__', type_)
+        args = [inner(a, {}) for a in getattr(type_, '__args__', [])]
+
+        if origin in TYPES:
+            return TYPES[origin](*args, **options)
+        warnings.warn(f"Unknown type {type_} at {cls.__name__}.{field.name}: {field.type} "
+                      f"It's advised to pass the correct marshmallow type to `mm_field`.")
+        return field.Field(**options)
+    return inner(type_, options)
+
+
+def schema(cls, mixin, infer_missing):
+    schema = {}
+    for field in dc_fields(cls):
+        if 'dataclasses_json' in (field.metadata or {}):
+            schema[field.name] = field.metadata['dataclasses_json'].get('mm_field')
+        else:
+            type_ = field.type
+            options = {}
+            missing_key = 'missing' if infer_missing else 'default'
+            if field.default is not MISSING:
+                options[missing_key] = field.default
+            elif field.default_factory is not MISSING:
+                options[missing_key] = field.default_factory
+
+            if options.get(missing_key, ...) is None:
+                options['allow_none'] = True
+
+            if _is_optional(type_):
+                options.setdefault(missing_key, None)
+                type_ = type_.__args__[0]
+                options['allow_none'] = True
+
+            t = build_type(type_, options, mixin, field, cls)
+            #if type(t) is not fields.Field:  # If we use `isinstance` we would return nothing.
+            schema[field.name] = t
+    return schema
+
+
+def build_schema(cls, mixin, infer_missing, partial):
+    Meta = type('Meta',
+                (),
+                {'fields': tuple(field.name for field in dc_fields(cls))})
+
+    @post_load
+    def make_instance(self, kvs):
+        return _decode_dataclass(cls, kvs, partial)
+
+    schema_ = schema(cls, mixin, infer_missing)
+    DataClassSchema = type(f'{cls.__name__.capitalize()}Schema',
+                           (Schema,),
+                           {'Meta': Meta,
+                            f'make_{cls.__name__.lower()}': make_instance,
+                            **schema_})
+
+    return DataClassSchema

--- a/tests/entities.py
+++ b/tests/entities.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass, field
-from datetime import datetime
 from typing import (Collection,
                     Deque,
                     Dict,
@@ -15,7 +14,6 @@ from uuid import UUID
 from marshmallow import fields
 
 from dataclasses_json import DataClassJsonMixin, dataclass_json
-from dataclasses_json.mm import _IsoField
 
 A = TypeVar('A')
 
@@ -155,38 +153,10 @@ class DataClassJsonDecorator:
 
 @dataclass_json
 @dataclass
-class DataClassWithDatetime:
-    created_at: datetime
-
-
-@dataclass_json
-@dataclass
 class DataClassWithOverride:
     id: float = field(
         metadata={'dataclasses_json': {
             'mm_field': fields.Integer()
-        }})
-
-
-@dataclass_json
-@dataclass
-class DataClassWithIsoDatetime:
-    created_at: datetime = field(
-        metadata={'dataclasses_json': {
-            'encoder': datetime.isoformat,
-            'decoder': datetime.fromisoformat,
-            'mm_field': fields.DateTime(format='iso')
-        }})
-
-
-@dataclass_json
-@dataclass
-class DataClassWithCustomIsoDatetime:
-    created_at: datetime = field(
-        metadata={'dataclasses_json': {
-            'encoder': datetime.isoformat,
-            'decoder': datetime.fromisoformat,
-            'mm_field': _IsoField()
         }})
 
 

--- a/tests/entities.py
+++ b/tests/entities.py
@@ -178,6 +178,7 @@ class DataClassWithIsoDatetime:
             'mm_field': fields.DateTime(format='iso')
         }})
 
+
 @dataclass_json
 @dataclass
 class DataClassWithCustomIsoDatetime:
@@ -189,8 +190,38 @@ class DataClassWithCustomIsoDatetime:
         }})
 
 
-
 @dataclass_json
 @dataclass
 class DataClassWithUuid:
     id: UUID
+
+
+@dataclass_json
+@dataclass
+class DataClassDefaultListStr:
+    value: List[str] = field(default_factory=list)
+
+
+@dataclass_json
+@dataclass
+class DataClassChild:
+    name: str
+
+
+@dataclass_json
+@dataclass
+class DataClassDefaultOptionalList:
+    children: Optional[List[DataClassChild]] = None
+
+
+@dataclass_json
+@dataclass
+class DataClassList:
+    children: List[DataClassChild]
+
+
+@dataclass_json
+@dataclass
+class DataClassOptional:
+    a: int
+    b: Optional[int]

--- a/tests/hypothesis2/strategies.py
+++ b/tests/hypothesis2/strategies.py
@@ -3,7 +3,7 @@ from collections import deque
 from hypothesis.strategies import lists, none, one_of
 
 
-def deques(elements=None, min_size=None, average_size=None, max_size=None,
+def deques(elements=None, min_size=0, max_size=None,
            unique_by=None, unique=False):
     return lists(**locals()).map(deque)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,14 +1,12 @@
-from datetime import datetime, timezone
 from uuid import UUID
 
 import pytest
 
 from tests.entities import (DataClassIntImmutableDefault, DataClassJsonDecorator,
-                            DataClassWithDataClass, DataClassWithDatetime,
-                            DataClassWithList, DataClassWithOptional,
-                            DataClassWithOptionalNested, DataClassWithUuid,
-                            DataClassWithIsoDatetime, DataClassWithOverride,
-                            DataClassWithCustomIsoDatetime, DataClassBoolImmutableDefault)
+                            DataClassWithDataClass, DataClassWithList,
+                            DataClassWithOptional, DataClassWithOptionalNested,
+                            DataClassWithUuid, DataClassWithOverride,
+                            DataClassBoolImmutableDefault)
 
 
 class TestTypes:
@@ -22,59 +20,6 @@ class TestTypes:
     def test_uuid_decode(self):
         assert (DataClassWithUuid.from_json(self.dc_uuid_json)
                 == DataClassWithUuid(UUID(self.uuid_s)))
-
-    dt = datetime(2018, 11, 17, 16, 55, 28, 456753, tzinfo=timezone.utc)
-    tz = timezone.utc
-
-    ts = dt.timestamp()
-    dc_ts_json = f'{{"created_at": {ts}}}'
-    dc_ts = DataClassWithDatetime(datetime.fromtimestamp(ts, tz=tz))
-
-    iso = dt.isoformat()
-    dc_iso_json = f'{{"created_at": "{iso}"}}'
-    dc_iso = DataClassWithIsoDatetime(datetime.fromisoformat(iso))
-
-    def test_datetime_encode(self):
-        assert (self.dc_ts.to_json() == self.dc_ts_json)
-
-    def test_datetime_decode(self):
-        assert (DataClassWithDatetime.from_json(self.dc_ts_json) == self.dc_ts)
-
-    def test_datetime_override_encode(self):
-        assert (self.dc_iso.to_json() == self.dc_iso_json)
-
-    def test_datetime_override_decode(self):
-        assert (DataClassWithIsoDatetime.from_json(
-            self.dc_iso_json) == self.dc_iso)
-
-    def test_datetime_schema_encode(self):
-        assert (DataClassWithDatetime.schema().dumps(self.dc_ts)
-                == self.dc_ts_json)
-
-    def test_datetime_schema_decode(self):
-        assert (DataClassWithDatetime.schema().loads(self.dc_ts_json)
-                == self.dc_ts)
-
-    def test_datetime_override_schema_encode(self):
-        assert (DataClassWithIsoDatetime.schema().dumps(self.dc_iso)
-                == self.dc_iso_json)
-
-    def test_datetime_override_schema_decode(self):
-        iso = DataClassWithIsoDatetime.schema().loads(self.dc_iso_json)
-        # FIXME bug in marshmallow currently returns datetime-naive instead of
-        # datetime-aware. also seems to drop microseconds?
-        # #955
-        iso.created_at = iso.created_at.replace(microsecond=456753,
-                                                tzinfo=self.tz)
-        assert (iso == self.dc_iso)
-
-    def test_datetime_custom_iso_fieldoverride_schema_encode(self):
-        assert (DataClassWithCustomIsoDatetime.schema().dumps(self.dc_iso)
-                == self.dc_iso_json)
-
-    def test_datetime_custom_iso_field_override_schema_decode(self):
-        iso = DataClassWithCustomIsoDatetime.schema().loads(self.dc_iso_json)
-        assert (iso == DataClassWithCustomIsoDatetime(self.dt))
 
 
 class TestInferMissing:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,23 @@
+from .entities import DataClassDefaultListStr, DataClassDefaultOptionalList, DataClassList, DataClassOptional
+
+
+test_do_list = """[{}, {"children": [{"name": "a"}, {"name": "b"}]}]"""
+test_list = '[{"children": [{"name": "a"}, {"name": "b"}]}]'
+
+
+class TestSchema:
+    def test_default_list_str(self):
+        DataClassDefaultListStr.schema().dumps(DataClassDefaultListStr())
+        assert True
+
+    def test_default_optional_list(self):
+        DataClassDefaultOptionalList.schema().loads(test_do_list, many=True)
+        assert True
+
+    def test_list(self):
+        DataClassList.schema().loads(test_list, many=True)
+        assert True
+
+    def test_optional(self):
+        DataClassOptional.schema().loads('{"a": 4, "b": null}')
+        assert True

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -1,0 +1,106 @@
+from datetime import datetime, timezone
+from dataclasses import dataclass, field
+import sys
+
+from marshmallow import fields
+import pytest
+
+from dataclasses_json import dataclass_json
+from dataclasses_json.mm import _IsoField
+
+
+@dataclass_json
+@dataclass
+class DataClassWithDatetime:
+    created_at: datetime
+
+
+if sys.version_info >= (3, 7):
+    @dataclass_json
+    @dataclass
+    class DataClassWithIsoDatetime:
+        created_at: datetime = field(
+            metadata={'dataclasses_json': {
+                'encoder': datetime.isoformat,
+                'decoder': datetime.fromisoformat,
+                'mm_field': fields.DateTime(format='iso')
+            }})
+
+
+    @dataclass_json
+    @dataclass
+    class DataClassWithCustomIsoDatetime:
+        created_at: datetime = field(
+            metadata={'dataclasses_json': {
+                'encoder': datetime.isoformat,
+                'decoder': datetime.fromisoformat,
+                'mm_field': _IsoField()
+            }})
+
+
+class TestTime:
+    dt = datetime(2018, 11, 17, 16, 55, 28, 456753, tzinfo=timezone.utc)
+    tz = timezone.utc
+
+    ts = dt.timestamp()
+    dc_ts_json = f'{{"created_at": {ts}}}'
+    dc_ts = DataClassWithDatetime(datetime.fromtimestamp(ts, tz=tz))
+
+    if sys.version_info >= (3, 7):
+        iso = dt.isoformat()
+        dc_iso_json = f'{{"created_at": "{iso}"}}'
+        dc_iso = DataClassWithIsoDatetime(datetime.fromisoformat(iso))
+
+    def test_datetime_encode(self):
+        assert (self.dc_ts.to_json() == self.dc_ts_json)
+
+    def test_datetime_decode(self):
+        assert (DataClassWithDatetime.from_json(self.dc_ts_json) == self.dc_ts)
+
+    @pytest.mark.skipif(sys.version_info < (3, 7),
+                        reason="requires python3.7")
+    def test_datetime_override_encode(self):
+        assert (self.dc_iso.to_json() == self.dc_iso_json)
+
+    @pytest.mark.skipif(sys.version_info < (3, 7),
+                        reason="requires python3.7")
+    def test_datetime_override_decode(self):
+        assert (DataClassWithIsoDatetime.from_json(
+            self.dc_iso_json) == self.dc_iso)
+
+    def test_datetime_schema_encode(self):
+        assert (DataClassWithDatetime.schema().dumps(self.dc_ts)
+                == self.dc_ts_json)
+
+    def test_datetime_schema_decode(self):
+        assert (DataClassWithDatetime.schema().loads(self.dc_ts_json)
+                == self.dc_ts)
+
+    @pytest.mark.skipif(sys.version_info < (3, 7),
+                        reason="requires python3.7")
+    def test_datetime_override_schema_encode(self):
+        assert (DataClassWithIsoDatetime.schema().dumps(self.dc_iso)
+                == self.dc_iso_json)
+
+    @pytest.mark.skipif(sys.version_info < (3, 7),
+                        reason="requires python3.7")
+    def test_datetime_override_schema_decode(self):
+        iso = DataClassWithIsoDatetime.schema().loads(self.dc_iso_json)
+        # FIXME bug in marshmallow currently returns datetime-naive instead of
+        # datetime-aware. also seems to drop microseconds?
+        # #955
+        iso.created_at = iso.created_at.replace(microsecond=456753,
+                                                tzinfo=self.tz)
+        assert (iso == self.dc_iso)
+
+    @pytest.mark.skipif(sys.version_info < (3, 7),
+                        reason="requires python3.7")
+    def test_datetime_custom_iso_fieldoverride_schema_encode(self):
+        assert (DataClassWithCustomIsoDatetime.schema().dumps(self.dc_iso)
+                == self.dc_iso_json)
+
+    @pytest.mark.skipif(sys.version_info < (3, 7),
+                        reason="requires python3.7")
+    def test_datetime_custom_iso_field_override_schema_decode(self):
+        iso = DataClassWithCustomIsoDatetime.schema().loads(self.dc_iso_json)
+        assert (iso == DataClassWithCustomIsoDatetime(self.dt))


### PR DESCRIPTION
In light of #68 I have updated the code to fix #57, #58, #60, #65, #67 and #68. I have added relevant tests and ensured they pass in Python 3.6 and 3.7. (I've changed the code to allow skipping of the datetime tests.)

From this I have moved all schema code into `mm` so that the marshmallow code is contained. And this is basically just a re-write of `mm`. I've updated `api` to accommodate these changes.

Otherwise only `core` has been changed. This is because marshmallow now loads schema data into the relevant model. (This can be tested against with code in #58). I'm unsure how you'd want the data to be handled, and so I chose to return early so I don't mangle with `core` too. **please verify this is the intended behavior**.

This should keep all the previous logic around options, most are in `schema` such as specifying a default, and handling `Optional`. The other special piece of logic is when creating a DC, I kept the `field_many` option. Otherwise `build_type` now builds all the types you'd previously specified, and a couple more, in a recursive form, defaulting to `fields.Field` and a warning.

---

I would like to request that we change how you handle the `dataclasses_json.mm_field` so that if the value is `None` we generate one by default. This isn't something you did previously, and so I didn't change this.