### PR TITLE
Reorder extraction to allow recursive encoding overrides to work

### DIFF
--- a/dataclasses_json/api.py
+++ b/dataclasses_json/api.py
@@ -35,8 +35,7 @@ class DataClassJsonMixin(abc.ABC):
                 default: Callable = None,
                 sort_keys: bool = False,
                 **kw) -> str:
-        kvs = _override(_asdict(self), _overrides(self), 'encoder')
-        return json.dumps(kvs,
+        return json.dumps(_asdict(self),
                           cls=_ExtendedEncoder,
                           skipkeys=skipkeys,
                           ensure_ascii=ensure_ascii,

--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -209,7 +209,7 @@ def _asdict(obj):
         for f in fields(obj):
             value = _asdict(getattr(obj, f.name))
             result.append((f.name, value))
-        return dict(result)
+        return _override(dict(result), _overrides(obj), 'encoder')
     elif isinstance(obj, Mapping):
         return dict((_asdict(k), _asdict(v)) for k, v in obj.items())
     elif isinstance(obj, Collection) and not isinstance(obj, str):


### PR DESCRIPTION
Hello,

This PR is meant to resolve issue #69. The problem is that overrides for encoding are only called at the top level, meaning any nested dataclasses do not have their configured overrides applied to them. By moving the `_overrides` and `_override` methods into `_asdict` the recursive calls to each of the fields in the nested dataclasses get their overrides applied.

I'm happy to apply any changes you see fit, and perhaps add some regression tests to ensure this recursive encoding behaviour is recorded.