### PR TITLE
Fix decoding of enums with mixins

### DIFF
--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -140,6 +140,9 @@ def _is_supported_generic(type_):
 def _decode_generic(type_, value, infer_missing):
     if value is None:
         res = value
+    elif _issubclass_safe(type_, Enum):
+        # Convert to an Enum using the type as a constructor. Assumes a direct match is found.
+        res = type_(value)
     elif _is_collection(type_):
         if _is_mapping(type_):
             k_type, v_type = type_.__args__
@@ -156,9 +159,6 @@ def _decode_generic(type_, value, infer_missing):
             res = _get_type_cons(type_)(xs)
         except TypeError:
             res = type_(xs)
-    elif _issubclass_safe(type_, Enum):
-        # Convert to an Enum using the type as a constructor. Assumes a direct match is found.
-        res = type_(value)
     else:  # Optional
         type_arg = type_.__args__[0]
         if is_dataclass(type_arg) or is_dataclass(value):

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -13,6 +13,8 @@ class MyEnum(Enum):
     INT1 = 1
     FLOAT1 = 1.23
 
+class MyStrEnum(str, Enum):
+    STR1 = "str1"
 
 @dataclass_json
 @dataclass(frozen=True)
@@ -33,6 +35,13 @@ d3_int_json = '{"name": "name1", "my_enum": 1}'
 d4_float = DataWithEnum('name1', MyEnum.FLOAT1)
 d4_float_json = '{"name": "name1", "my_enum": 1.23}'
 
+@dataclass_json
+@dataclass(frozen=True)
+class DataWithStrEnum:
+    my_str_enum: MyStrEnum = MyEnum.STR1
+
+ds = DataWithStrEnum(MyStrEnum.STR1)
+ds_json = '{"my_str_enum": "str1"}'
 
 @dataclass_json
 @dataclass(frozen=True)
@@ -52,6 +61,9 @@ class TestEncoder:
         assert d1.to_json() == d1_json, f'Actual: {d1.to_json()}, Expected: {d1_json}'
         assert d3_int.to_json() == d3_int_json, f'Actual: {d3_int.to_json()}, Expected: {d3_int_json}'
         assert d4_float.to_json() == d4_float_json, f'Actual: {d4_float.to_json()}, Expected: {d4_float_json}'
+
+    def test_data_with_str_enum(self):
+        assert ds.to_json() == ds_json, f'Actual: {ds.to_json()}, Expected: {ds_json}'
 
     def test_data_with_enum_default_value(self):
         d2_to_json = d2_using_default_value.to_json()
@@ -75,6 +87,11 @@ class TestDecoder:
         d4_float_from_json = DataWithEnum.from_json(d4_float_json)
         assert d4_float == d4_float_from_json
         assert d4_float_from_json.to_json() == d4_float_json
+
+    def test_data_with_str_enum(self):
+        ds_from_json = DataWithStrEnum.from_json(ds_json)
+        assert ds == ds_from_json
+        assert ds_from_json.to_json() == ds_json
 
     def test_data_with_enum_default_value(self):
         d2_from_json = DataWithEnum.from_json(d2_json)


### PR DESCRIPTION
Fixes #75.

Move up the enum check in _decode_generic to ensure that enums are decoded
properly regardless of any mixin classes.
`MyEnum(str, Enum)` was handled incorrectly as collection before, for
example.

