### PR TITLE
Add Jackson style subtype parsing

### DIFF
--- a/dataclasses_json/api.py
+++ b/dataclasses_json/api.py
@@ -4,7 +4,7 @@ from typing import Any, Callable, List, Optional, Tuple, TypeVar, Union
 
 from dataclasses_json.mm import build_schema
 from dataclasses_json.core import (_ExtendedEncoder, _asdict, _decode_dataclass,
-                                   _overrides, _override)
+                                   _overrides, _override, JsonTypeInfo, JsonSubtypeInfo)
 
 A = TypeVar('A')
 B = TypeVar('B')
@@ -83,12 +83,108 @@ class DataClassJsonMixin(abc.ABC):
                       unknown=unknown)
 
 
-def dataclass_json(cls):
-    cls.to_json = DataClassJsonMixin.to_json
-    # unwrap and rewrap classmethod to tag it to cls rather than the literal
-    # DataClassJsonMixin ABC
-    cls.from_json = classmethod(DataClassJsonMixin.from_json.__func__)
-    cls.schema = classmethod(DataClassJsonMixin.schema.__func__)
-    # register cls as a virtual subclass of DataClassJsonMixin
-    DataClassJsonMixin.register(cls)
-    return cls
+def dataclass_json(
+        _cls=None, *,
+        parse_as_subtype=False,
+        subtype_property='@type',
+        register_subtype_of=None,
+        subtype_id=None):
+    """
+    Decorator for attaching to_json()/from_json(s) methods to a class.
+
+    Usage Without Parens:
+    >>> @dataclass_json
+    ... @dataclass
+    ... class A:
+    ...   x : int
+    >>>
+    >>> a = A(12)
+    >>>
+    >>> # Encoing to JSON
+    >>> a.to_json()  # '{"x": 12}'
+    >>>
+    >>> # Decoding from JSON
+    >>> a.from_json('{"x": 12}')  # A(x=12)
+
+    Declaring a base class which can delegeate from_json()
+    to registered subclasses:
+    >>> @dataclass_json(parse_as_subtype=True)
+    >>> @dataclass(frozen=True)
+    >>> class Base:
+    >>>     x: int
+    >>> 
+    >>> @dataclass_json(register_subtype_of=Base)
+    >>> @dataclass(frozen=True)
+    >>> class Foo(Base):
+    >>>     y: str
+    >>> 
+    >>> b = Base(1)
+    >>> foo = Foo(2, 'abc')
+    >>>
+    >>> b.to_json()  # '{"x": 1}'
+    >>> foo.to_json()  # '{"x": 2, "y": "abc", "@type": "Foo"}'
+    >>>
+    >>> Base.from_json('{"x": 3}') # Base(3)
+    >>> Base.from_json('{"x": 2, "y": "abc", "@type": "Foo"}') # Foo(2, "abc")
+
+    The subtype_property defaults to '@type',
+    but can be overriden on the baseclass annotation.
+
+    The subtype_id defaults to the __name__ of the subtype,
+    but can be overriden on the subtype annotation.
+
+    Examples:
+    >>> @dataclass_json(parse_as_subtype=True, subtype_property='@id')
+    >>> @dataclass(frozen=True)
+    >>> class Base:
+    >>>     x: int
+    >>> 
+    >>> @dataclass_json(register_subtype_of=Base, subtype_id='f')
+    >>> @dataclass(frozen=True)
+    >>> class Foo(Base):
+    >>>     y: str
+    >>> 
+    >>> b = Base(1)
+    >>> foo = Foo(2, 'abc')
+    >>>
+    >>> b.to_json()  # '{"x": 1}'
+    >>> foo.to_json()  # '{"x": 2, "y": "abc", "@id": "f"}'
+    >>>
+    >>> Base.from_json('{"x": 3}') # Base(3)
+    >>> Base.from_json('{"x": 2, "y": "abc", "@id": "f"}') # Foo(2, "abc")
+    """
+
+    def wrap(cls):
+        cls.to_json = DataClassJsonMixin.to_json
+        # unwrap and rewrap classmethod to tag it to cls rather than the literal
+        # DataClassJsonMixin ABC
+        cls.from_json = classmethod(DataClassJsonMixin.from_json.__func__)
+        cls.schema = classmethod(DataClassJsonMixin.schema.__func__)
+        # register cls as a virtual subclass of DataClassJsonMixin
+        DataClassJsonMixin.register(cls)
+
+        if parse_as_subtype:
+            cls._jsontypeinfo_ = JsonTypeInfo(type_parameter=subtype_property)
+
+        if register_subtype_of is not None:
+            basetype = register_subtype_of
+
+            if not hasattr(basetype, '_jsontypeinfo_'):
+                raise ValueError(
+                    ("@dataclass_json(register_subtype_of=%s) requires "
+                     "@dataclass_json(parse_as_subtype=True) on %s")
+                        % (basetype.__name__, basetype.__name__))
+
+            key = subtype_id if subtype_id is not None else cls.__name__
+            typeinfo = basetype._jsontypeinfo_
+
+            cls._jsonsubtypeinfo_ = JsonSubtypeInfo(typeinfo, key)
+            basetype._jsontypeinfo_.add_subtype(key, cls)
+
+        return cls
+
+    if _cls is None:
+        return wrap
+
+    return wrap(_cls)
+

--- a/tests/test_subclasses.py
+++ b/tests/test_subclasses.py
@@ -1,0 +1,94 @@
+from dataclasses import dataclass
+from typing import List
+
+from dataclasses_json import dataclass_json
+
+@dataclass_json(parse_as_subtype=True)
+@dataclass(frozen=True)
+class Base:
+    x: int
+
+
+@dataclass_json(register_subtype_of=Base)
+@dataclass(frozen=True)
+class SubclassFoo(Base):
+    y: str
+
+
+@dataclass_json(register_subtype_of=Base, subtype_id='bar')
+@dataclass(frozen=True)
+class SubclassBar(Base):
+    z: int
+
+
+@dataclass_json
+@dataclass(frozen=True)
+class BaseContainer:
+    id: int
+    children: List[Base]
+
+
+@dataclass_json(parse_as_subtype=True, subtype_property='@id')
+@dataclass(frozen=True)
+class BaseWCustomProperty:
+    x: int
+
+
+@dataclass_json(register_subtype_of=BaseWCustomProperty, subtype_id='sub')
+@dataclass(frozen=True)
+class CustomPropertySub(BaseWCustomProperty):
+    y: str
+
+
+b = Base(1)
+foo = SubclassFoo(2, 'abc')
+bar = SubclassBar(3, 45)
+
+c = BaseContainer(999, [b, foo, bar])
+
+class TestSubclasses:
+    def test_custom_proprety(self):
+        bb = BaseWCustomProperty(22)
+        sub = CustomPropertySub(33, 'j')
+
+        assert bb.to_json() == '{"x": 22}'
+        assert sub.to_json() == '{"x": 33, "y": "j", "@id": "sub"}'
+
+        psub = BaseWCustomProperty.from_json(
+            '{"x": 33, "y": "j", "@id": "sub"}')
+
+        assert psub == sub
+
+    def test_badsubclass(self):
+        class X:
+            pass
+
+        try:
+          @dataclass_json(register_subtype_of=X)
+          @dataclass(frozen=True)
+          class BadSubclass(X):
+              z: int
+
+        except ValueError as e:
+            assert 'parse_as_subtype' in e.args[0], e
+        
+    def test_base(self):
+        assert b.to_json() == '{"x": 1}'
+
+    def test_foo(self):
+        assert foo.to_json() == '{"x": 2, "y": "abc", "@type": "SubclassFoo"}'
+
+    def test_bar(self):
+        assert bar.to_json() == '{"x": 3, "z": 45, "@type": "bar"}'
+
+    def test_container(self):
+        assert c.to_json() == \
+            '{"id": 999, "children": [' \
+            '{"x": 1}, ' \
+            '{"x": 2, "y": "abc", "@type": "SubclassFoo"}, ' \
+            '{"x": 3, "z": 45, "@type": "bar"}]}'
+
+    def test_parse(self):
+        pc = BaseContainer.from_json(c.to_json())
+
+        assert pc == c


### PR DESCRIPTION
```
    Declaring a base class which can delegeate from_json()
    to registered subclasses:
    >>> @dataclass_json(parse_as_subtype=True)
    >>> @dataclass(frozen=True)
    >>> class Base:
    >>>     x: int
    >>> 
    >>> @dataclass_json(register_subtype_of=Base)
    >>> @dataclass(frozen=True)
    >>> class Foo(Base):
    >>>     y: str
    >>> 
    >>> b = Base(1)
    >>> foo = Foo(2, 'abc')
    >>>
    >>> b.to_json()  # '{"x": 1}'
    >>> foo.to_json()  # '{"x": 2, "y": "abc", "@type": "Foo"}'
    >>>
    >>> Base.from_json('{"x": 3}') # Base(3)
    >>> Base.from_json('{"x": 2, "y": "abc", "@type": "Foo"}') # Foo(2, "abc")
```