### PR TITLE
Marshmallow enum support (#51) (#63) (#83)

### DIFF
--- a/dataclasses_json/mm.py
+++ b/dataclasses_json/mm.py
@@ -4,13 +4,14 @@ import warnings
 from dataclasses import MISSING, is_dataclass, fields as dc_fields
 from datetime import datetime
 from uuid import UUID
+from enum import Enum
 
 from marshmallow import fields, Schema, post_load
+from marshmallow_enum import EnumField
 
 from dataclasses_json.core import _is_supported_generic, _decode_dataclass
 from dataclasses_json.utils import (_is_collection, _is_optional,
                                     _issubclass_safe, _timestamp_to_dt_aware)
-
 
 
 class _TimestampField(fields.Field):
@@ -46,6 +47,7 @@ TYPES = {
     UUID: fields.UUID
 }
 
+
 def build_type(type_, options, mixin, field, cls):
     def inner(type_, options):
         if is_dataclass(type_):
@@ -67,6 +69,10 @@ def build_type(type_, options, mixin, field, cls):
 
         if origin in TYPES:
             return TYPES[origin](*args, **options)
+
+        if _issubclass_safe(origin, Enum):
+            return EnumField(enum=origin, by_value=True, *args, **options)
+
         warnings.warn(f"Unknown type {type_} at {cls.__name__}.{field.name}: {field.type} "
                       f"It's advised to pass the correct marshmallow type to `mm_field`.")
         return fields.Field(**options)

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ setup(
     keywords="dataclasses json",
     install_requires=[
         "dataclasses;python_version=='3.6'",
-        "marshmallow>=3.0.0b20"
+        "marshmallow>=3.0.0b20",
+        "marshmallow-enum>=1.4.1"
     ],
     python_requires=">=3.6",
     extras_require={

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -1,9 +1,13 @@
+import json
 from enum import Enum
 from typing import Dict, List
+import pytest
 
 from dataclasses import dataclass
 
 from dataclasses_json import dataclass_json
+
+from marshmallow.exceptions import ValidationError
 
 
 class MyEnum(Enum):
@@ -13,8 +17,10 @@ class MyEnum(Enum):
     INT1 = 1
     FLOAT1 = 1.23
 
+
 class MyStrEnum(str, Enum):
     STR1 = "str1"
+
 
 @dataclass_json
 @dataclass(frozen=True)
@@ -35,13 +41,16 @@ d3_int_json = '{"name": "name1", "my_enum": 1}'
 d4_float = DataWithEnum('name1', MyEnum.FLOAT1)
 d4_float_json = '{"name": "name1", "my_enum": 1.23}'
 
+
 @dataclass_json
 @dataclass(frozen=True)
 class DataWithStrEnum:
     my_str_enum: MyStrEnum = MyEnum.STR1
 
+
 ds = DataWithStrEnum(MyStrEnum.STR1)
 ds_json = '{"my_str_enum": "str1"}'
+
 
 @dataclass_json
 @dataclass(frozen=True)
@@ -104,3 +113,60 @@ class TestDecoder:
         container_from_json = EnumContainer.from_json(container_json)
         assert container == container_from_json
         assert container_from_json.to_json() == container_json
+
+
+class TestValidator:
+    @pytest.mark.parametrize('enum_value, is_valid', [
+        ('str1', True),
+        ('str2', True),
+        ('str3', True),
+        (1, True),
+        (1.23, True),
+        ('str4', False),
+        (2, False),
+        (1.24, False),
+    ])
+    def test_data_with_enum(self, enum_value, is_valid):
+        data = '{"name": "myname", "my_enum": "' + str(enum_value) + '"}'
+        schema = DataWithEnum.schema()
+        res = schema.validate(json.loads(data))
+        assert not res == is_valid
+
+    @pytest.mark.parametrize('enum_value, is_valid', [
+        ('str1', True),
+        ('str2', False),
+    ])
+    def test_data_with_str_enum(self, enum_value, is_valid):
+        data = '{"my_str_enum": "' + str(enum_value) + '"}'
+        schema = DataWithStrEnum.schema()
+        res = schema.validate(json.loads(data))
+        assert not res == is_valid
+
+
+class TestLoader:
+    @pytest.mark.parametrize('json_data, expected_data', [
+        (d1_json, d1),
+        (d2_json, d2_using_default_value),
+        (d3_int_json, d3_int),
+        (d4_float_json, d4_float),
+    ])
+    def test_data_with_enum(self, json_data, expected_data):
+        schema = DataWithEnum.schema()
+        assert schema.loads(json_data) == expected_data
+
+    def test_data_with_enum_exception(self):
+        schema = DataWithEnum.schema()
+        with pytest.raises(ValidationError):
+            schema.loads('{"name": "name1", "my_enum": "str4"}')
+
+    @pytest.mark.parametrize('json_data, expected_data', [
+        (ds_json, ds),
+    ])
+    def test_data_with_str_enum(self, json_data, expected_data):
+        schema = DataWithStrEnum.schema()
+        assert schema.loads(json_data) == expected_data
+
+    def test_data_with_str_enum_exception(self):
+        schema = DataWithStrEnum.schema()
+        with pytest.raises(ValidationError):
+            schema.loads('{"my_str_enum": "str2"}')


### PR DESCRIPTION
- New Enums will be handled (or processed) as EnumField in marshmallow schema
- Added unit tests