### PR TITLE
Fixes for type annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ necessarily want to assign a default. In that case, you can use the
 @dataclass
 class Tutor:
     id: int
-    student: Optional[Student]
+    student: Optional[Student] = None
 
 Tutor.from_json('{"id": 1}')  # Tutor(id=1, student=None)
 ```

--- a/dataclasses_json/api.py
+++ b/dataclasses_json/api.py
@@ -2,7 +2,7 @@ import abc
 import json
 from typing import Any, Callable, List, Optional, Tuple, TypeVar, Union, Type
 
-from dataclasses_json.mm import build_schema, SchemaHelper
+from dataclasses_json.mm import build_schema, SchemaHelper, JsonData
 from dataclasses_json.core import _ExtendedEncoder, _asdict, _decode_dataclass
 
 A = TypeVar('A')
@@ -43,7 +43,7 @@ class DataClassJsonMixin(abc.ABC):
 
     @classmethod
     def from_json(cls: Type[A],
-                  s: str,
+                  s: JsonData,
                   *,
                   encoding=None,
                   parse_float=None,

--- a/dataclasses_json/api.py
+++ b/dataclasses_json/api.py
@@ -1,8 +1,8 @@
 import abc
 import json
-from typing import Any, Callable, List, Optional, Tuple, TypeVar, Union
+from typing import Any, Callable, List, Optional, Tuple, TypeVar, Union, Type
 
-from dataclasses_json.mm import build_schema
+from dataclasses_json.mm import build_schema, SchemaHelper
 from dataclasses_json.core import _ExtendedEncoder, _asdict, _decode_dataclass
 
 A = TypeVar('A')
@@ -70,7 +70,7 @@ class DataClassJsonMixin(abc.ABC):
                load_only=(),
                dump_only=(),
                partial: bool = False,
-               unknown=None) -> MMSchema:
+               unknown=None) -> SchemaHelper[A]:
         Schema = build_schema(cls, DataClassJsonMixin, infer_missing, partial)
         return Schema(only=only,
                       exclude=exclude,

--- a/dataclasses_json/api.py
+++ b/dataclasses_json/api.py
@@ -42,7 +42,7 @@ class DataClassJsonMixin(abc.ABC):
                           **kw)
 
     @classmethod
-    def from_json(cls: A,
+    def from_json(cls: Type[A],
                   s: str,
                   *,
                   encoding=None,
@@ -60,17 +60,17 @@ class DataClassJsonMixin(abc.ABC):
         return _decode_dataclass(cls, kvs, infer_missing)
 
     @classmethod
-    def schema(cls,
+    def schema(cls: Type[A],
                *,
-               infer_missing=False,
+               infer_missing: bool = False,
                only=None,
                exclude=(),
-               many=False,
+               many: bool = False,
                context=None,
                load_only=(),
                dump_only=(),
-               partial=False,
-               unknown=None):
+               partial: bool = False,
+               unknown=None) -> MMSchema:
         Schema = build_schema(cls, DataClassJsonMixin, infer_missing, partial)
         return Schema(only=only,
                       exclude=exclude,

--- a/dataclasses_json/mm.py
+++ b/dataclasses_json/mm.py
@@ -52,6 +52,7 @@ TYPES = {
 }
 
 T = typing.TypeVar('T')
+JsonData = typing.Union[str, bytes, bytearray]
 TEncoded = typing.Dict[str, typing.Any]
 TOneOrMulti = typing.Union[typing.List[T], T]
 TOneOrMultiEncoded = typing.Union[typing.List[TEncoded], TEncoded]
@@ -96,16 +97,16 @@ class SchemaHelper(Schema, typing.Generic[T]):
         pass
 
     @typing.overload
-    def loads(self, json_data: str,
+    def loads(self, json_data: JsonData,
               many: bool = True, partial: bool = None, unknown: bool = None,
               **kwargs) -> typing.List[T]:
         pass
     @typing.overload
-    def loads(self, json_data: str,
+    def loads(self, json_data: JsonData,
               many: None = None, partial: bool = None, unknown: bool = None,
               **kwargs) -> T:
         pass
-    def loads(self, json_data: str,
+    def loads(self, json_data: JsonData,
               many: bool = None, partial: bool = None, unknown: bool = None,
               **kwargs) -> TOneOrMulti:
         pass

--- a/dataclasses_json/mm.py
+++ b/dataclasses_json/mm.py
@@ -51,6 +51,65 @@ TYPES = {
     Decimal: fields.Decimal
 }
 
+T = typing.TypeVar('T')
+TEncoded = typing.Dict[str, typing.Any]
+TOneOrMulti = typing.Union[typing.List[T], T]
+TOneOrMultiEncoded = typing.Union[typing.List[TEncoded], TEncoded]
+class SchemaHelper(Schema, typing.Generic[T]):
+    def __init__(self, *args, **kwargs):
+        """
+        Raises exception because this class should not be inherited.
+        This class is helper only.
+        """
+
+        super().__init__(*args, **kwargs)
+        raise NotImplementedError()
+
+    @typing.overload
+    def dump(self, obj: typing.List[T], many: bool = None) -> typing.List[TEncoded]:
+        pass
+    @typing.overload
+    def dump(self, obj: T, many: bool = None) -> TEncoded:
+        pass
+    def dump(self, obj: TOneOrMulti, many: bool = None) -> TOneOrMultiEncoded:
+        pass
+
+    @typing.overload
+    def dumps(self, obj: typing.List[T], many: bool = None, *args, **kwargs) -> str:
+        pass
+    @typing.overload
+    def dumps(self, obj: T, many: bool = None, *args, **kwargs) -> str:
+        pass
+    def dumps(self, obj: TOneOrMulti, many: bool = None, *args, **kwargs) -> str:
+        pass
+
+    @typing.overload
+    def load(self, data: typing.List[TEncoded],
+             many: bool = True, partial: bool = None, unknown: bool = None) -> typing.List[T]:
+        pass
+    @typing.overload
+    def load(self, data: TEncoded,
+             many: None = None, partial: bool = None, unknown: bool = None) -> T:
+        pass
+    def load(self, data: TOneOrMultiEncoded,
+             many: bool = None, partial: bool = None, unknown: bool = None) -> TOneOrMulti:
+        pass
+
+    @typing.overload
+    def loads(self, json_data: str,
+              many: bool = True, partial: bool = None, unknown: bool = None,
+              **kwargs) -> typing.List[T]:
+        pass
+    @typing.overload
+    def loads(self, json_data: str,
+              many: None = None, partial: bool = None, unknown: bool = None,
+              **kwargs) -> T:
+        pass
+    def loads(self, json_data: str,
+              many: bool = None, partial: bool = None, unknown: bool = None,
+              **kwargs) -> TOneOrMulti:
+        pass
+
 
 def build_type(type_, options, mixin, field, cls):
     def inner(type_, options):
@@ -116,8 +175,7 @@ def schema(cls, mixin, infer_missing):
             schema[field.name] = t
     return schema
 
-
-def build_schema(cls, mixin, infer_missing, partial):
+def build_schema(cls: typing.Type[T], mixin, infer_missing, partial) -> typing.Type[SchemaHelper[T]]:
     Meta = type('Meta',
                 (),
                 {'fields': tuple(field.name for field in dc_fields(cls))})
@@ -133,9 +191,9 @@ def build_schema(cls, mixin, infer_missing, partial):
         return Schema.dumps(self, *args, **kwargs)
 
     schema_ = schema(cls, mixin, infer_missing)
-    DataClassSchema = type(f'{cls.__name__.capitalize()}Schema',
-                           (Schema,),
-                           {'Meta': Meta,
+    DataClassSchema: typing.Type[SchemaHelper[T]] = type(f'{cls.__name__.capitalize()}Schema',
+                                                         (Schema,),
+                                                         {'Meta': Meta,
                             f'make_{cls.__name__.lower()}': make_instance,
                             'dumps': dumps,
                             **schema_})

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -1,0 +1,41 @@
+import json
+
+# noinspection PyCompatibility
+from dataclasses import dataclass
+from dataclasses_json import DataClassJsonMixin
+
+from typing import List, Dict, Any
+from mypy.main import main as mypy_main
+
+@dataclass
+class User(DataClassJsonMixin):
+    id: str
+    name: str = "John"
+
+class TestAnnotations:
+    u: User = User('ax9ssFxH')
+    j: str = u.to_json()
+    u2: User = User.from_json(j)
+    u2a: User = User.from_json(j.encode())
+
+    jMany = [{"id":"115412", "name": "Peter"}, {"id": "atxXxGhg", "name": "Parker"}]
+    sch = User.schema()
+    users1: List[User] = sch.loads(json.dumps(jMany), many=True)
+    n: str = users1[1].name
+    users2: List[User] = sch.load(jMany, many=True)
+    u3: User = sch.load(jMany[1])
+    j2: Dict[str, Any] = sch.dump(u)
+    j3: List[Dict[str, Any]] = sch.dump([u2, u3], many=True)
+    j4: str = sch.dumps(u2)
+
+    def test_type_hints(self):
+        try:
+            mypy_main(None, [ __file__  ])
+        except SystemExit:
+            passed = False
+        else:
+            passed = True
+
+        # To prevent large errors
+        if (not passed):
+            raise AssertionError("Type annotations check failed")

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -1,16 +1,24 @@
 import json
+import os
+import sys
 
 # noinspection PyCompatibility
 from dataclasses import dataclass
 from dataclasses_json import DataClassJsonMixin
-
-from typing import List, Dict, Any
+from io import StringIO
 from mypy.main import main as mypy_main
+from typing import List, Dict, Any, Tuple, NewType, Optional, Union
 
 @dataclass
 class User(DataClassJsonMixin):
     id: str
     name: str = "John"
+
+
+Filename = NewType('Filename', str)
+LineNumber = NewType('LineNumber', int)
+ErrorLevel = NewType('ErrorLevel', str)
+ErrorMessage = NewType('ErrorMessage', str)
 
 class TestAnnotations:
     u: User = User('ax9ssFxH')
@@ -28,14 +36,82 @@ class TestAnnotations:
     j3: List[Dict[str, Any]] = sch.dump([u2, u3], many=True)
     j4: str = sch.dumps(u2)
 
+    def filter_errors(self, errors: List[str]) -> List[str]:
+        real_errors: List[str] = list()
+        current_file = __file__
+        current_path = os.path.split(current_file)
+
+        for line in errors:
+            line = line.strip()
+            if (not line):
+                continue
+
+            fn, lno, lvl, msg = self.parse_trace_line(line)
+            if (fn is not None):
+                _path = os.path.split(fn)
+                if (_path[-1] != current_path[-1]):
+                    continue
+
+            real_errors.append(line)
+
+        return real_errors
+
+    def parse_trace_line(self, line: str) -> \
+            Tuple[Optional[Filename], Optional[LineNumber], Optional[ErrorLevel], ErrorMessage]:
+        # Define variables
+        file_name: Union[str, Filename, None]
+        line_no: Union[str, LineNumber, None]
+        level: Union[str, ErrorLevel, None]
+        msg: Union[str, ErrorMessage, None]
+
+        where, sep, msg = line.partition(': ')
+        if (sep):
+            file_name, sep, line_no = where.partition(':')
+            file_name = Filename(file_name)
+            if (sep):
+                line_no = LineNumber(int(line_no))
+            else:
+                line_no = None
+
+            level, sep, msg = msg.partition(': ')
+            if (sep):
+                level = ErrorLevel(level)
+            else:
+                msg = level
+                level = None
+
+        else:
+            file_name = None
+            line_no = None
+            level = None
+            msg = line
+
+        msg = ErrorMessage(msg)
+        return file_name, line_no, level, msg
+
+
     def test_type_hints(self):
+        old_stdout = sys.stdout
+        old_stderr = sys.stderr
+        text_io = StringIO('')
         try:
+            # mypy.main uses sys.stdout for printing
+            # We override it to catch error messages
+            sys.stdout = text_io
+            sys.stderr = text_io
             mypy_main(None, [ __file__  ])
         except SystemExit:
-            passed = False
+            # mypy.main could return errors found inside other files.
+            # filter_errors() will filter out all errors outside this file.
+            errors = text_io.getvalue().splitlines()
+            errors = self.filter_errors(errors)
         else:
-            passed = True
+            errors = None
+        finally:
+            sys.stdout = old_stdout
+            sys.stderr = old_stderr
 
-        # To prevent large errors
-        if (not passed):
+        # To prevent large errors raise error out of try/except
+        if (errors):
+            print('\n'.join(errors))
             raise AssertionError("Type annotations check failed")

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Set
+from typing import Set, Optional
 
 from dataclasses_json import dataclass_json
 
@@ -9,6 +9,13 @@ from dataclasses_json import dataclass_json
 class Student:
     id: int = 0
     name: str = ""
+
+
+@dataclass_json
+@dataclass
+class Tutor:
+    id: int
+    student: Optional[Student] = None
 
 
 @dataclass_json
@@ -29,6 +36,7 @@ class Course:
 
 s1 = Student(1, 'student')
 s2 = Student(2, 'student')
+t = Tutor(id=1, student=None)
 p = Professor(1, 'professor')
 c = Course(1, 'course', p, {s1})
 
@@ -50,3 +58,8 @@ class TestEncoder:
         two = [s2_anon, s1_anon]
         actual = Student.schema().loads('[{"id": 1}, {"id": 2}]', many=True)
         assert actual == one or actual == two
+
+
+class TestDecoder:
+    def test_tutor(self):
+        assert Tutor.from_json('{"id": 1}') == t


### PR DESCRIPTION
### What was changed:
 - Fixed type annotation for `DataClassJsonMixin.from_json()`: was `A -> A`, now `Type[A] -> A`.
 - Fixed invalid example in ReadMe (one with Tutor)
 - Extended possible argument types for all `loads()` methods (including `from_json()`): was `str`, now `Union[str, bytes, bytearray]`. This now matches the `json.loads()` prototype.
 - Added `class SchemaHelper[T]`, which provides type annotations for generated schemas.
 - `DataClassJsonMixin.schema()` is now `Type[A] -> SchemaHelper[A]`

### Tests:
 - Added tests for type annotations: `test_annotations.py`. They start mypy and check the current file.
 - Added tests for Tutor in `test_example.py`

### Fixes:
 - #91: Invalid code example in ReadMe
 - #88: Doubt regarding Type Annotation in "from_json"

##### P.S.
If you have any doubts in `test_annotations.py`, try changing any type annotation in the test class and see how your tests start failing.