### PR TITLE
Union type support (#82)

### DIFF
--- a/dataclasses_json/mm.py
+++ b/dataclasses_json/mm.py
@@ -7,6 +7,8 @@ from decimal import Decimal
 from uuid import UUID
 from enum import Enum
 
+from typing_inspect import is_union_type
+
 from marshmallow import fields, Schema, post_load
 from marshmallow_enum import EnumField
 
@@ -14,7 +16,7 @@ from dataclasses_json.core import (_is_supported_generic, _decode_dataclass,
                                    _ExtendedEncoder)
 from dataclasses_json.utils import (_is_collection, _is_optional,
                                     _issubclass_safe, _timestamp_to_dt_aware,
-                                    _is_new_type)
+                                    _is_new_type, _get_type_origin)
 
 
 class _TimestampField(fields.Field):
@@ -31,6 +33,50 @@ class _IsoField(fields.Field):
 
     def _deserialize(self, value, attr, data, **kwargs):
         return datetime.fromisoformat(value)
+
+
+class _UnionField(fields.Field):
+    def __init__(self, desc, cls, field, *args, **kwargs):
+        self.desc = desc
+        self.cls = cls
+        self.field = field
+        super().__init__(*args, **kwargs)
+
+    def _serialize(self, value, attr, obj, **kwargs):
+        if self.allow_none and value is None:
+            return None
+        for type_, schema_ in self.desc.items():
+            if _issubclass_safe(type(value), type_):
+                if is_dataclass(value):
+                    res = schema_._serialize(value, attr, obj, **kwargs)
+                    res['__type'] = str(type_.__name__)
+                    return res
+                break
+            elif isinstance(value, _get_type_origin(type_)):
+                return schema_._serialize(value, attr, obj, **kwargs)
+        else:
+            warnings.warn(f'The type "{type(value).__name__}" (value: "{value}") '
+                          f'is not in the list of possible types of typing.Union '
+                          f'(dataclass: {self.cls.__name__}, field: {self.field.name}). '
+                          f'Value cannot be serialized properly.')
+        return super()._serialize(value, attr, obj, **kwargs)
+
+    def _deserialize(self, value, attr, data, **kwargs):
+        if isinstance(value, dict) and '__type' in value:
+            dc_name = value['__type']
+            for type_, schema_ in self.desc.items():
+                if is_dataclass(type_) and type_.__name__ == dc_name:
+                    del value['__type']
+                    return schema_._deserialize(value, attr, data, **kwargs)
+        for type_, schema_ in self.desc.items():
+            if isinstance(value, _get_type_origin(type_)):
+                return schema_._deserialize(value, attr, data, **kwargs)
+        else:
+            warnings.warn(f'The type "{type(value).__name__}" (value: "{value}") '
+                          f'is not in the list of possible types of typing.Union '
+                          f'(dataclass: {self.cls.__name__}, field: {self.field.name}). '
+                          f'Value cannot be deserialized properly.')
+        return super()._deserialize(value, attr, data, **kwargs)
 
 
 TYPES = {
@@ -75,13 +121,18 @@ def build_type(type_, options, mixin, field, cls):
                 return fields.Field(**options)
 
         origin = getattr(type_, '__origin__', type_)
-        args = [inner(a, {}) for a in getattr(type_, '__args__', [])]
+        args = [inner(a, {}) for a in getattr(type_, '__args__', []) if a is not type(None)]
 
         if origin in TYPES:
             return TYPES[origin](*args, **options)
 
         if _issubclass_safe(origin, Enum):
             return EnumField(enum=origin, by_value=True, *args, **options)
+
+        if is_union_type(type_):
+            union_types = [a for a in getattr(type_, '__args__', []) if a is not type(None)]
+            union_desc = dict(zip(union_types, args))
+            return _UnionField(union_desc, cls, field, **options)
 
         warnings.warn(f"Unknown type {type_} at {cls.__name__}.{field.name}: {field.type} "
                       f"It's advised to pass the correct marshmallow type to `mm_field`.")
@@ -108,8 +159,10 @@ def schema(cls, mixin, infer_missing):
 
             if _is_optional(type_):
                 options.setdefault(missing_key, None)
-                type_ = type_.__args__[0]
                 options['allow_none'] = True
+                if len(type_.__args__) == 2:
+                    # Union[str, int, None] is optional too, but it has more than 1 typed field.
+                    type_ = type_.__args__[0]
 
             t = build_type(type_, options, mixin, field, cls)
             #if type(t) is not fields.Field:  # If we use `isinstance` we would return nothing.

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,8 @@ setup(
     install_requires=[
         "dataclasses;python_version=='3.6'",
         "marshmallow>=3.0.0rc6",
-        "marshmallow-enum>=1.4.1"
+        "marshmallow-enum>=1.4.1",
+        "typing-inspect>=0.4.0"
     ],
     python_requires=">=3.6",
     extras_require={

--- a/tests/test_union.py
+++ b/tests/test_union.py
@@ -1,0 +1,144 @@
+import pytest
+from typing import *
+from dataclasses import dataclass
+from dataclasses_json import dataclass_json
+from marshmallow import ValidationError
+
+
+# == Common use cases ==
+@dataclass_json
+@dataclass
+class C1:
+    f1: Union[int, str]
+
+
+@dataclass_json
+@dataclass
+class C2:
+    f1: Union[int, Dict[str, float]]
+
+
+@dataclass_json
+@dataclass
+class C3:
+    f1: Union[int, List[float]]
+
+
+# == Use cases with nested dataclasses ==
+@dataclass_json
+@dataclass
+class Aux1:
+    f1: int
+
+
+@dataclass_json
+@dataclass
+class Aux2:
+    f1: str
+
+
+@dataclass_json
+@dataclass
+class C4:
+    f1: Union[Aux1, Aux2]
+
+
+@dataclass_json
+@dataclass
+class C5:
+    f1: Union[Aux1, Aux2, None]
+
+
+@dataclass_json
+@dataclass
+class C6:
+    f1: Union[Aux1, None]  # The same as Optional[Aux1]
+
+
+@dataclass_json
+@dataclass
+class C7:
+    f1: Union[C5, C6]
+
+
+@dataclass_json
+@dataclass
+class C8:
+    f1: Dict[str, Union[Aux1, Aux2]]
+
+
+@dataclass_json
+@dataclass
+class C9:
+    f1: List[Union[Aux1, Aux2]]
+
+
+params = [
+    (C1(f1=12), {"f1": 12}, '{"f1": 12}'),
+    (C1(f1="str1"), {"f1": "str1"}, '{"f1": "str1"}'),
+
+    (C2(f1=10), {"f1": 10}, '{"f1": 10}'),
+    (C2(f1={"str1": 0.12}), {"f1": {"str1": 0.12}}, '{"f1": {"str1": 0.12}}'),
+
+    (C3(f1=10), {"f1": 10}, '{"f1": 10}'),
+    (C3(f1=[0.12, 0.13, 0.14]), {"f1": [0.12, 0.13, 0.14]}, '{"f1": [0.12, 0.13, 0.14]}'),
+
+    (C4(f1=Aux1(1)), {"f1": {"f1": 1, "__type": "Aux1"}}, '{"f1": {"f1": 1, "__type": "Aux1"}}'),
+    (C4(f1=Aux2("str1")), {"f1": {"f1": "str1", "__type": "Aux2"}}, '{"f1": {"f1": "str1", "__type": "Aux2"}}'),
+
+    (C5(f1=Aux1(1)), {"f1": {"f1": 1, "__type": "Aux1"}}, '{"f1": {"f1": 1, "__type": "Aux1"}}'),
+    (C5(f1=Aux2("str1")), {"f1": {"f1": "str1", "__type": "Aux2"}}, '{"f1": {"f1": "str1", "__type": "Aux2"}}'),
+    (C5(f1=None), {"f1": None}, '{"f1": null}'),
+
+    (C6(f1=Aux1(1)), {"f1": {"f1": 1}}, '{"f1": {"f1": 1}}'),  # For Optionals, type can be clearly defined
+    (C6(f1=None), {"f1": None}, '{"f1": null}'),
+
+    (C7(C5(Aux2("str1"))),
+     {"f1": {"f1": {"f1": "str1", "__type": "Aux2"}, "__type": "C5"}},
+     '{"f1": {"f1": {"f1": "str1", "__type": "Aux2"}, "__type": "C5"}}'),
+    (C7(C6(Aux1(12))),
+     {"f1": {"f1": {"f1": 12}, "__type": "C6"}},
+     '{"f1": {"f1": {"f1": 12}, "__type": "C6"}}'),
+
+    (C8({"str1": Aux1(12), "str2": Aux2("str3")}),
+     {"f1": {"str1": {"f1": 12, "__type": "Aux1"}, "str2": {"f1": "str3", "__type": "Aux2"}}},
+     '{"f1": {"str1": {"f1": 12, "__type": "Aux1"}, "str2": {"f1": "str3", "__type": "Aux2"}}}'),
+
+    (C9([Aux1(12), Aux2("str3")]),
+     {"f1": [{"f1": 12, "__type": "Aux1"}, {"f1": "str3", "__type": "Aux2"}]},
+     '{"f1": [{"f1": 12, "__type": "Aux1"}, {"f1": "str3", "__type": "Aux2"}]}')
+]
+
+
+@pytest.mark.parametrize('obj, expected, expected_json', params)
+def test_serialize(obj, expected, expected_json):
+    s = obj.schema()
+    assert s.dump(obj) == expected
+    assert s.dumps(obj) == expected_json
+
+
+@pytest.mark.parametrize('expected_obj, data, data_json', params)
+def test_deserialize(expected_obj, data, data_json):
+    cls = type(expected_obj)
+    s = cls.schema()
+    assert s.load(data) == expected_obj
+    assert s.loads(data_json) == expected_obj
+
+
+@pytest.mark.parametrize('obj', [
+    (C2(f1={"str1": "str1"})),
+    (C3(f1=[0.12, 0.13, "str1"])),
+])
+def test_serialize_with_error(obj):
+    s = obj.schema()
+    with pytest.raises(ValidationError):
+        assert s.dump(obj)
+
+
+@pytest.mark.parametrize('cls, data', [
+    (C1, {"f1": None}),
+])
+def test_deserialize_with_error(cls, data):
+    s = cls.schema()
+    with pytest.raises(ValidationError):
+        assert s.load(data)


### PR DESCRIPTION
- Added new class _UnionField for handling typing.Union (in the serialized data of the classes listed in the Union[...], a new field "__type" will appear)
- Added unit tests

Note:
Only works through the use of the "schema" field:
```
schema = <dataclass>.schema()
schema.dump(<dataclass_instance>)  # for serialization to python dict
schema.dumps(<dataclass_instance>)  # for serialization to json
```
and 
```
schema = <dataclass>.schema()
schema.load(<py_dict>)  # for serialization from python dict
schema.loads(<json_str>)  # for serialization from json
```

`<dataclass>.to_json(<dataclass_instance>)` and `<dataclass>.from_json(<json_str>)` methods are not affected because to_json method does not use marshmallow.