### PR TITLE
Added support for from_json() accepting dict in addition to str-like types

### DIFF
--- a/dataclasses_json/api.py
+++ b/dataclasses_json/api.py
@@ -1,6 +1,6 @@
 import abc
 import json
-from typing import Any, Callable, List, Optional, Tuple, TypeVar, Union, Type
+from typing import Any, Callable, List, Optional, Tuple, TypeVar, Union, Type, overload
 
 from dataclasses_json.mm import build_schema, SchemaType, JsonData
 from dataclasses_json.core import _ExtendedEncoder, _asdict, _decode_dataclass
@@ -42,6 +42,7 @@ class DataClassJsonMixin(abc.ABC):
                           **kw)
 
     @classmethod
+    @overload
     def from_json(cls: Type[A],
                   s: JsonData,
                   *,
@@ -51,12 +52,36 @@ class DataClassJsonMixin(abc.ABC):
                   parse_constant=None,
                   infer_missing=False,
                   **kw) -> A:
-        kvs = json.loads(s,
-                         encoding=encoding,
-                         parse_float=parse_float,
-                         parse_int=parse_int,
-                         parse_constant=parse_constant,
-                         **kw)
+        pass
+
+    @classmethod
+    @overload
+    def from_json(cls: Type[A],
+                  s: dict,
+                  *,
+                  infer_missing=False,
+                  ) -> A:
+        pass
+
+    @classmethod
+    def from_json(cls: Type[A],
+                  s: Union[JsonData, dict],
+                  *,
+                  encoding=None,
+                  parse_float=None,
+                  parse_int=None,
+                  parse_constant=None,
+                  infer_missing=False,
+                  **kw) -> A:
+        if (isinstance(s, dict)):
+            kvs = s
+        else:
+            kvs = json.loads(s,
+                             encoding=encoding,
+                             parse_float=parse_float,
+                             parse_int=parse_int,
+                             parse_constant=parse_constant,
+                             **kw)
         return _decode_dataclass(cls, kvs, infer_missing)
 
     @classmethod

--- a/dataclasses_json/mm.py
+++ b/dataclasses_json/mm.py
@@ -284,7 +284,7 @@ def build_schema(cls: typing.Type[A],
         return Schema.dumps(self, *args, **kwargs)
 
     schema_ = schema(cls, mixin, infer_missing)
-    DataClassSchema: SchemaType = type(
+    DataClassSchema: typing.Type[SchemaType] = type(
         f'{cls.__name__.capitalize()}Schema',
         (Schema,),
         {'Meta': Meta,

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     ],
     python_requires=">=3.6",
     extras_require={
-        "dev": ["pytest", "ipython", "mypy", "hypothesis"]
+        "dev": ["pytest", "ipython", "mypy>=0.710", "hypothesis"]
     },
     include_package_data=True
 )

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -36,6 +36,10 @@ class TestAnnotations:
     j3: List[Dict[str, Any]] = sch.dump([u2, u3], many=True)
     j4: str = sch.dumps(u2)
 
+    j4_dict: Dict[str, Any] = json.loads(j4)
+    u4a: User = User.from_json(j4)
+    u4b: User = User.from_json(j4_dict)
+
     def filter_errors(self, errors: List[str]) -> List[str]:
         real_errors: List[str] = list()
         current_file = __file__

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -91,15 +91,11 @@ class TestAnnotations:
 
 
     def test_type_hints(self):
-        old_stdout = sys.stdout
-        old_stderr = sys.stderr
         text_io = StringIO('')
         try:
             # mypy.main uses sys.stdout for printing
             # We override it to catch error messages
-            sys.stdout = text_io
-            sys.stderr = text_io
-            mypy_main(None, [ __file__  ])
+            mypy_main(None, text_io, text_io, [__file__])
         except SystemExit:
             # mypy.main could return errors found inside other files.
             # filter_errors() will filter out all errors outside this file.
@@ -107,9 +103,6 @@ class TestAnnotations:
             errors = self.filter_errors(errors)
         else:
             errors = None
-        finally:
-            sys.stdout = old_stdout
-            sys.stderr = old_stderr
 
         # To prevent large errors raise error out of try/except
         if (errors):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,3 +1,4 @@
+import json
 from decimal import Decimal
 from uuid import UUID
 
@@ -30,6 +31,22 @@ class TestTypes:
     def test_uuid_encode(self):
         assert (DataClassWithUuid(UUID(self.uuid_s)).to_json()
                 == self.dc_uuid_json)
+
+    def test_uuid_decode(self):
+        assert (DataClassWithUuid.from_json(self.dc_uuid_json)
+                == DataClassWithUuid(UUID(self.uuid_s)))
+
+
+class TestDictDecode:
+    decimal_s = "12345.12345"
+    dc_decimal_json = {"x": decimal_s}
+
+    uuid_s = 'd1d61dd7-c036-47d3-a6ed-91cc2e885fc8'
+    dc_uuid_json = {"id": uuid_s}
+
+    def test_decimal_decode(self):
+        assert (DataClassWithDecimal.from_json(self.dc_decimal_json)
+                == DataClassWithDecimal(Decimal(self.decimal_s)))
 
     def test_uuid_decode(self):
         assert (DataClassWithUuid.from_json(self.dc_uuid_json)


### PR DESCRIPTION
### Problem:
Sometimes, you already have loaded json (i.e., from the function result, from json5, from yaml, etc.)
This will help to avoid such construction:
```python
loaded: dict = json5.load(my_opened_file)
data: MyDataclass = MyDataclass.from_json(json.dumps(loaded))
```

Of course, you can always use schema loaders, but there are still redundant calls:
```python
data: MyDataclass = MyDataclass.schema().load(loaded)
```

### Changelog:
 - Added overload for api.from_json() - it now accepts dict in addition to str, bytes and bytearray
 - Added api and annotation tests covering this scenario.
 - Other minor fixes/improvements:
   - `mm.py`: Minor type annotation issue fixed
   - Annotation Tests: added support for mypy of 0.710+
   - `setup.py`: now mypy of 0.710+ is required
