### PR TITLE
Fix Marshmallow schema generation for `letter_case` allow `field_name`

### DIFF
--- a/dataclasses_json/api.py
+++ b/dataclasses_json/api.py
@@ -1,4 +1,5 @@
 import abc
+import functools
 import json
 from enum import Enum
 from typing import (Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar,
@@ -23,12 +24,40 @@ class LetterCase(Enum):
     SNAKE = snakecase
 
 
-def config(*,
+def config(metadata: dict = None, *,
            encoder: callable = None,
            decoder: callable = None,
            mm_field: MarshmallowField = None,
-           letter_case: LetterCase = None) -> Dict[str, dict]:
-    return {'dataclasses_json': locals()}
+           letter_case: Callable[[str], str] = None,
+           field_name: str = None) -> Dict[str, dict]:
+    if metadata is None:
+        metadata = {}
+
+    data = metadata.setdefault('dataclasses_json', {})
+
+    if encoder is not None:
+        data['encoder'] = encoder
+
+    if decoder is not None:
+        data['decoder'] = decoder
+
+    if mm_field is not None:
+        data['mm_field'] = mm_field
+
+    if field_name is not None:
+        if letter_case is not None:
+            @functools.wraps(letter_case)
+            def override(_, _letter_case=letter_case, _field_name=field_name):
+                return _letter_case(_field_name)
+        else:
+            def override(_, _field_name=field_name):
+                return _field_name
+        letter_case = override
+
+    if letter_case is not None:
+        data['letter_case'] = letter_case
+
+    return metadata
 
 
 class DataClassJsonMixin(abc.ABC):

--- a/dataclasses_json/api.py
+++ b/dataclasses_json/api.py
@@ -79,7 +79,7 @@ class DataClassJsonMixin(abc.ABC):
                 default: Callable = None,
                 sort_keys: bool = False,
                 **kw) -> str:
-        return json.dumps(self.to_dict(),
+        return json.dumps(self.to_dict(encode_json=False),
                           cls=_ExtendedEncoder,
                           skipkeys=skipkeys,
                           ensure_ascii=ensure_ascii,
@@ -116,8 +116,8 @@ class DataClassJsonMixin(abc.ABC):
                   infer_missing=False) -> A:
         return _decode_dataclass(cls, kvs, infer_missing)
 
-    def to_dict(self):
-        return _asdict(self)
+    def to_dict(self, encode_json=False):
+        return _asdict(self, encode_json=encode_json)
 
     @classmethod
     def schema(cls: Type[A],

--- a/dataclasses_json/api.py
+++ b/dataclasses_json/api.py
@@ -79,7 +79,7 @@ class DataClassJsonMixin(abc.ABC):
                 default: Callable = None,
                 sort_keys: bool = False,
                 **kw) -> str:
-        return json.dumps(_asdict(self),
+        return json.dumps(self.to_dict(),
                           cls=_ExtendedEncoder,
                           skipkeys=skipkeys,
                           ensure_ascii=ensure_ascii,

--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -69,18 +69,20 @@ def _encode_json_type(value, default=_ExtendedEncoder().default):
     return default(value)
 
 
-def _encode_overrides(kvs, overrides):
+def _encode_overrides(kvs, overrides, encode_json=False):
     override_kvs = {}
     for k, v in kvs.items():
         if k in overrides:
             letter_case = overrides[k].letter_case
-            encode_k = letter_case(k) if letter_case is not None else k
+            original_key = k
+            k = letter_case(k) if letter_case is not None else k
 
-            encoder = overrides[k].encoder
-            encoder = encoder if encoder is not None else _encode_json_type
-            override_kvs[encode_k] = encoder(v)
-        else:
-            override_kvs[k] = v
+            encoder = overrides[original_key].encoder
+            v = encoder(v) if encoder is not None else v
+
+        if encode_json:
+            v = _encode_json_type(v)
+        override_kvs[k] = v
     return override_kvs
 
 
@@ -263,7 +265,7 @@ def _decode_items(type_arg, xs, infer_missing):
     return items
 
 
-def _asdict(obj):
+def _asdict(obj, encode_json=False):
     """
     A re-implementation of `asdict` (based on the original in the `dataclasses`
     source) to support arbitrary Collection and Mapping types.
@@ -271,12 +273,12 @@ def _asdict(obj):
     if _is_dataclass_instance(obj):
         result = []
         for field in fields(obj):
-            value = _asdict(getattr(obj, field.name))
+            value = _asdict(getattr(obj, field.name), encode_json=encode_json)
             result.append((field.name, value))
-        return _encode_overrides(dict(result), _user_overrides(obj))
+        return _encode_overrides(dict(result), _user_overrides(obj), encode_json=encode_json)
     elif isinstance(obj, Mapping):
-        return dict((_asdict(k), _asdict(v)) for k, v in obj.items())
+        return dict((_asdict(k, encode_json=encode_json), _asdict(v, encode_json=encode_json)) for k, v in obj.items())
     elif isinstance(obj, Collection) and not isinstance(obj, str):
-        return list(_asdict(v) for v in obj)
+        return list(_asdict(v, encode_json=encode_json) for v in obj)
     else:
         return copy.deepcopy(obj)

--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -63,6 +63,12 @@ def _user_overrides(cls):
     return overrides
 
 
+def _encode_json_type(value, default=_ExtendedEncoder().default):
+    if isinstance(value, Json.__args__):
+        return value
+    return default(value)
+
+
 def _encode_overrides(kvs, overrides):
     override_kvs = {}
     for k, v in kvs.items():
@@ -71,7 +77,8 @@ def _encode_overrides(kvs, overrides):
             encode_k = letter_case(k) if letter_case is not None else k
 
             encoder = overrides[k].encoder
-            override_kvs[encode_k] = encoder(v) if encoder is not None else v
+            encoder = encoder if encoder is not None else _encode_json_type
+            override_kvs[encode_k] = encoder(v)
         else:
             override_kvs[k] = v
     return override_kvs

--- a/dataclasses_json/mm.py
+++ b/dataclasses_json/mm.py
@@ -237,9 +237,9 @@ def build_type(type_, options, mixin, field, cls):
 def schema(cls, mixin, infer_missing):
     schema = {}
     for field in dc_fields(cls):
-        if 'dataclasses_json' in (field.metadata or {}):
-            schema[field.name] = field.metadata['dataclasses_json'].get(
-                'mm_field')
+        metadata = (field.metadata or {}).get('dataclasses_json', {})
+        if 'mm_field' in metadata:
+            schema[field.name] = metadata['mm_field']
         else:
             type_ = field.type
             options = {}

--- a/tests/test_letter_case.py
+++ b/tests/test_letter_case.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 
-from dataclasses_json import LetterCase, dataclass_json
+from dataclasses_json import LetterCase, dataclass_json, config
 
 
 @dataclass_json
@@ -33,6 +33,12 @@ class SnakeCasePerson:
     )
 
 
+@dataclass_json
+@dataclass
+class FieldNamePerson:
+    given_name: str = field(metadata=config(field_name='givenName'))
+
+
 class TestLetterCase:
     def test_camel_encode(self):
         assert CamelCasePerson('Alice').to_json() == '{"givenName": "Alice"}'
@@ -54,3 +60,16 @@ class TestLetterCase:
     def test_snake_decode(self):
         assert SnakeCasePerson.from_json(
             '{"given_name": "Alice"}') == SnakeCasePerson('Alice')
+
+    def test_field_name_encode(self):
+        assert FieldNamePerson('Alice').to_json() == '{"givenName": "Alice"}'
+
+    def test_field_name_decode(self):
+        assert FieldNamePerson.from_json(
+            '{"givenName": "Alice"}') == FieldNamePerson('Alice')
+
+    def test_from_dict(self):
+        assert CamelCasePerson.from_dict({'givenName': 'Alice'}) == CamelCasePerson('Alice')
+
+    def test_to_dict(self):
+        assert {'givenName': 'Alice'} == CamelCasePerson('Alice').to_dict()


### PR DESCRIPTION
Fixes schema generation #107 and allows setting raw `field_name` #116 #110 #115
JSON-type encodable `to_dict()` #118 