### PR TITLE
Union support bugfix

### DIFF
--- a/dataclasses_json/mm.py
+++ b/dataclasses_json/mm.py
@@ -1,6 +1,7 @@
 import typing
 import warnings
 import sys
+from copy import deepcopy
 
 from dataclasses import MISSING, is_dataclass, fields as dc_fields
 from datetime import datetime
@@ -64,22 +65,23 @@ class _UnionField(fields.Field):
         return super()._serialize(value, attr, obj, **kwargs)
 
     def _deserialize(self, value, attr, data, **kwargs):
-        if isinstance(value, dict) and '__type' in value:
-            dc_name = value['__type']
+        tmp_value = deepcopy(value)
+        if isinstance(tmp_value, dict) and '__type' in tmp_value:
+            dc_name = tmp_value['__type']
             for type_, schema_ in self.desc.items():
                 if is_dataclass(type_) and type_.__name__ == dc_name:
-                    del value['__type']
-                    return schema_._deserialize(value, attr, data, **kwargs)
+                    del tmp_value['__type']
+                    return schema_._deserialize(tmp_value, attr, data, **kwargs)
         for type_, schema_ in self.desc.items():
-            if isinstance(value, _get_type_origin(type_)):
-                return schema_._deserialize(value, attr, data, **kwargs)
+            if isinstance(tmp_value, _get_type_origin(type_)):
+                return schema_._deserialize(tmp_value, attr, data, **kwargs)
         else:
             warnings.warn(
-                f'The type "{type(value).__name__}" (value: "{value}") '
+                f'The type "{type(tmp_value).__name__}" (value: "{tmp_value}") '
                 f'is not in the list of possible types of typing.Union '
                 f'(dataclass: {self.cls.__name__}, field: {self.field.name}). '
                 f'Value cannot be deserialized properly.')
-        return super()._deserialize(value, attr, data, **kwargs)
+        return super()._deserialize(tmp_value, attr, data, **kwargs)
 
 
 TYPES = {

--- a/tests/test_union.py
+++ b/tests/test_union.py
@@ -125,6 +125,16 @@ def test_deserialize(expected_obj, data, data_json):
     assert s.loads(data_json) == expected_obj
 
 
+def test_deserialize_twice():
+    data = {"f1": [{"f1": 12, "__type": "Aux1"}, {"f1": "str3", "__type": "Aux2"}]}
+    expected_obj = C9([Aux1(12), Aux2("str3")])
+
+    s = C9.schema()
+    res1 = s.load(data)
+    res2 = s.load(data)
+    assert res1 == expected_obj and res2 == expected_obj
+
+
 @pytest.mark.parametrize('obj', [
     (C2(f1={"str1": "str1"})),
     (C3(f1=[0.12, 0.13, "str1"])),


### PR DESCRIPTION
Prevents impact on the original serialized data during Union deserialization.
Previously, the field “__type” was being removed from the original data, which made it impossible to deserialize from the original data twice.