### PR TITLE
Aliased functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,3 +495,55 @@ boss_json = """
 assert boss.to_json(indent=4) == boss_json
 assert Boss.from_json(boss_json) == boss
 ```
+
+## Serializing Callable Fields
+Dataclasses with fields that aren't serializable, like a function object, require some extra
+work to make sure they can be serialized and deserialized.  There are two decorators to 
+help with this for functions and bound methods.
+
+### Functions
+```python
+from dataclasses import dataclass, field
+from typing import Callable, Dict
+
+from dataclasses_json import dataclass_json
+from dataclasses_json.callable_alias import  function_alias, aliased_function_field
+
+@function_alias("hello-world-function")
+def greet(data: Dict) -> Dict:
+    print(data[FunctionNode.KEY])
+    return data
+
+
+@dataclass_json
+@dataclass
+class FunctionNode:
+    KEY = "msg"
+    name: str
+    # First argument is list of arguments.  Second argument is the return type.
+    callable: Callable[[Dict], Dict] = field(metadata=aliased_function_field)
+```
+
+### Bound Method
+```python
+from dataclasses import dataclass, field
+from typing import Callable, Dict
+
+from dataclasses_json import dataclass_json
+from dataclasses_json.callable_alias import  method_alias, aliased_method_field
+
+
+class Greeter:
+    @method_alias("hello-world-method")
+    def greet(self, data: Dict) -> Dict:
+        print(data[MethodNode.KEY])
+        return data
+
+@dataclass_json
+@dataclass
+class MethodNode:
+    KEY = "msg"
+    name: str
+    # First argument is list of arguments.  Second argument is the return type.
+    callable: Callable[[Dict], Dict] = field(metadata=aliased_method_field)
+```

--- a/README.md
+++ b/README.md
@@ -501,6 +501,8 @@ Dataclasses with fields that aren't serializable, like a function object, requir
 work to make sure they can be serialized and deserialized.  There are two decorators to 
 help with this for functions and bound methods.
 
+Note: This won't work with functions or bound methods that have free variables/closures.
+
 ### Functions
 ```python
 from dataclasses import dataclass, field

--- a/dataclasses_json/callable_alias.py
+++ b/dataclasses_json/callable_alias.py
@@ -1,0 +1,121 @@
+import sys
+from typing import Callable, Dict
+
+from marshmallow import fields
+
+_callable_to_alias_map = dict()
+_alias_to_callable_map = dict()
+
+
+def function_alias(alias: str):
+    """
+    Decorator factory to add a function to the alias <-> callable maps.
+    :param alias: Alias for the decorated function.
+    :return: Decorator
+    """
+
+    def function_alias_decorator(function: Callable[[Dict], Dict]):
+        """
+        Add the function to the alias <-> function map.
+        :param function: Decorated function to map.
+        :return: Decorated function.
+        """
+        if alias in _alias_to_callable_map:
+            raise KeyError(f"Function alias '{alias}' already mapped.")
+        _callable_to_alias_map[function] = alias
+        _alias_to_callable_map[alias] = function
+        return function
+
+    return function_alias_decorator
+
+
+def method_alias(alias: str):
+    """
+    Decorator factory to add a method to the alias <-> callable maps.
+    :param alias: Alias for the decorated method.
+    :return: Decorator
+    """
+
+    def method_alias_decorator(method: Callable[[Dict], Dict]):
+        """
+        Add the method to the alias <-> function map.
+        :param method: Decorated method to map.
+        :return: Decorated function.
+        """
+        key = method_key(method)
+        if alias in _alias_to_callable_map:
+            raise KeyError(f"Method alias '{alias}' already mapped.")
+        _callable_to_alias_map[key] = alias
+        _alias_to_callable_map[alias] = key
+        return method
+
+    return method_alias_decorator
+
+
+def method_key(method: Callable) -> str:
+    """Fully qualified class name module.class.method"""
+    return f"{method.__module__}.{method.__qualname__}"
+
+
+class AliasedFunctionField(fields.Field):
+    """
+    Serializer to convert the function field to it's string representation for serialization.
+    """
+
+    def _serialize(self, value, attr, obj, **kwargs):
+        return _callable_to_alias_map[value]
+
+    @staticmethod
+    def encoder(*args, **kwargs):
+        return _callable_to_alias_map[args[0]]
+
+    @staticmethod
+    def decoder(*args, **kwargs):
+        return _alias_to_callable_map[args[0]]
+
+
+aliased_function_field = {
+    "dataclasses_json": {
+        "encoder": AliasedFunctionField.encoder,
+        "decoder": AliasedFunctionField.decoder,
+        "mm_field": AliasedFunctionField(),
+    }
+}
+
+
+class AliasedMethodField(fields.Field):
+    """
+    Serializer to convert the method field to it's string representation for serialization.
+    """
+
+    def _serialize(self, value, attr, obj, **kwargs):
+        return _callable_to_alias_map[method_key(value)]
+
+    def _deserialize(self, value, attr, data, **kwargs):
+        key = _alias_to_callable_map[value]
+        module, cls, method = key.rsplit(".", 2)
+        obj = getattr(sys.modules[module], cls)(**kwargs)
+        return getattr(obj, method)
+
+    @staticmethod
+    def encoder(*args, **kwargs):
+        return _callable_to_alias_map[method_key(args[0])]
+
+    @staticmethod
+    def decoder(*args, **kwargs):
+        # Check to see if the object has already been decoded and just return it.
+        if not isinstance(args[0], str):
+            return args[0]
+        key = _alias_to_callable_map[args[0]]
+        module, cls, method = key.rsplit(".", 2)
+        obj = getattr(sys.modules[module], cls)(**kwargs)
+        return getattr(obj, method)
+
+
+aliased_method_field = {
+    "dataclasses_json": {
+        "encoder": AliasedMethodField.encoder,
+        "decoder": AliasedMethodField.decoder,
+        "mm_field": AliasedMethodField(),
+    }
+}

--- a/tests/test_callable_alias.py
+++ b/tests/test_callable_alias.py
@@ -1,0 +1,91 @@
+import copy
+from dataclasses import dataclass, field
+from typing import Callable, Dict
+
+from dataclasses_json import dataclass_json
+from dataclasses_json.callable_alias import  function_alias, aliased_function_field, method_alias, aliased_method_field
+
+
+@function_alias("hello-world-function")
+def greet(data: Dict) -> Dict:
+    print(data[FunctionNode.KEY])
+    return copy.deepcopy(data)
+
+
+class Greeter:
+    @method_alias("hello-world-method")
+    def greet(self, data: Dict) -> Dict:
+        print(data[MethodNode.KEY])
+        return data
+
+
+@dataclass_json
+@dataclass
+class FunctionNode:
+    KEY = "msg"
+    name: str
+    # First argument is list of arguments.  Second argument is the return type.
+    callable: Callable[[Dict], Dict] = field(metadata=aliased_function_field)
+
+
+@dataclass_json
+@dataclass
+class MethodNode:
+    KEY = "msg"
+    name: str
+    # First argument is list of arguments.  Second argument is the return type.
+    callable: Callable[[Dict], Dict] = field(metadata=aliased_method_field)
+
+
+def _validate_function(capsys, node, node_dict, node_obj):
+    assert node_dict["callable"] == "hello-world-function"
+    assert node_obj.name == "Hello"
+    assert node_obj.callable == greet
+    assert node_obj == node
+    input = {FunctionNode.KEY: "Hello, World!"}
+    result = node_obj.callable(input)
+    assert result == input
+    out = capsys.readouterr().out
+    assert out.strip() == input[FunctionNode.KEY]
+
+
+def test_aliased_function_dict(capsys):
+    node = FunctionNode("Hello", greet)
+    node_dict = FunctionNode.to_dict(node)
+    node_obj = FunctionNode.from_dict(node_dict)
+    _validate_function(capsys, node, node_dict, node_obj)
+
+
+def test_aliased_function_schema(capsys):
+    node = FunctionNode("Hello", greet)
+    node_dict = FunctionNode.schema().dump(node)
+    node_obj = FunctionNode.schema().load(node_dict)
+    _validate_function(capsys, node, node_dict, node_obj)
+
+
+def _validate_method(capsys, node_dict, node_obj):
+    assert node_dict["callable"] == "hello-world-method"
+    assert node_obj.name == "Hello"
+    input = {FunctionNode.KEY: "Hello, World!"}
+    result = node_obj.callable(input)
+    assert result == input
+    out = capsys.readouterr().out
+    assert out.strip() == input[FunctionNode.KEY]
+
+
+def test_aliased_method_dict(capsys):
+    greeter = Greeter()
+    node = MethodNode("Hello", greeter.greet)
+    node_dict = MethodNode.to_dict(node)
+    node_obj = MethodNode.from_dict(node_dict)
+    assert node_dict["callable"] == "hello-world-method"
+    _validate_method(capsys, node_dict, node_obj)
+
+
+def test_aliased_method_schema(capsys):
+    greeter = Greeter()
+    node = MethodNode("Hello", greeter.greet)
+    node_dict = MethodNode.schema().dump(node)
+    node_obj = MethodNode.schema().load(node_dict)
+    assert node_dict["callable"] == "hello-world-method"
+    _validate_method(capsys, node_dict, node_obj)


### PR DESCRIPTION
New functionality to support serializing/deserializing none serializable functions and bound methods.   The decorators take an alias name to build maps between the function/method and the alias and the other way around.  When the object is serialized the function/method is replaced with the alias.  When deserialized the alias is converted back to the function/method.

I kept all of the functionality in a new module (callable_alias) in case we don't decide to merge this.  If we do merge this functionality I'd be happy to update __init__ and move the code into core and api as appropriate.