### PR TITLE
feat: make @dataclass_json take optional args and remove @configured_dataclass_json

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,11 @@ SimpleExample.from_dict({'int_field': 1})  # SimpleExample(1)
 **What if you want to work with camelCase JSON?**
 
 ```python
-# same imports as above
+# same imports as above, with the additional `LetterCase` import
 from dataclasses import dataclass
-from dataclasses_json import dataclass_json
+from dataclasses_json import dataclass_json, LetterCase
 
-# and then a couple of new imports
-from dataclasses_json import configured_dataclass_json, LetterCase
-
-@configured_dataclass_json(letter_case=LetterCase.CAMEL)  # now all fields are encoded/decoded from camelCase
+@dataclass_json(letter_case=LetterCase.CAMEL)  # now all fields are encoded/decoded from camelCase
 @dataclass
 class ConfiguredSimpleExample:
     int_field: int
@@ -451,13 +448,6 @@ class DataClassWithIsoDatetime:
         }}
     )
 ```
-
-
-#### Doing it at the class-level / for all fields?
-
-Use the `configured_dataclass_json` decorator instead of `dataclass_json`. See [Quickstart](#Quickstart)
-
-If you're using `DataClassJsonMixin`, you'll need to manually set the attribute `MyDataClass.dataclass_json_config`.
 
 ## A larger example
 

--- a/dataclasses_json/__init__.py
+++ b/dataclasses_json/__init__.py
@@ -1,2 +1,4 @@
-from dataclasses_json.api import (DataClassJsonMixin, LetterCase, config,
-                                  dataclass_json, configured_dataclass_json)
+from dataclasses_json.api import (DataClassJsonMixin,
+                                  LetterCase,
+                                  config,
+                                  dataclass_json)

--- a/dataclasses_json/api.py
+++ b/dataclasses_json/api.py
@@ -142,7 +142,29 @@ class DataClassJsonMixin(abc.ABC):
                       unknown=unknown)
 
 
-def dataclass_json(cls):
+def dataclass_json(_cls=None, *, letter_case=None):
+    """
+    Based on the code in the `dataclasses` module to handle optional-parens
+    decorators. See example below:
+
+    @dataclass_json
+    @dataclass_json(letter_case=Lettercase.CAMEL)
+    class Example:
+        ...
+    """
+
+    def wrap(cls):
+        return _process_class(cls, letter_case)
+
+    if _cls is None:
+        return wrap
+    return wrap(_cls)
+
+
+def _process_class(cls, letter_case):
+    if letter_case is not None:
+        cls.dataclass_json_config = config(letter_case=letter_case)[
+            'dataclasses_json']
     cls.to_json = DataClassJsonMixin.to_json
     # unwrap and rewrap classmethod to tag it to cls rather than the literal
     # DataClassJsonMixin ABC
@@ -153,13 +175,3 @@ def dataclass_json(cls):
     # register cls as a virtual subclass of DataClassJsonMixin
     DataClassJsonMixin.register(cls)
     return cls
-
-
-def configured_dataclass_json(*, letter_case=None):
-    def dec(cls):
-        cls = dataclass_json(cls)
-        cls.dataclass_json_config = config(letter_case=letter_case)[
-            'dataclasses_json']
-        return cls
-
-    return dec

--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -275,9 +275,12 @@ def _asdict(obj, encode_json=False):
         for field in fields(obj):
             value = _asdict(getattr(obj, field.name), encode_json=encode_json)
             result.append((field.name, value))
-        return _encode_overrides(dict(result), _user_overrides(obj), encode_json=encode_json)
+        return _encode_overrides(dict(result), _user_overrides(obj),
+                                 encode_json=encode_json)
     elif isinstance(obj, Mapping):
-        return dict((_asdict(k, encode_json=encode_json), _asdict(v, encode_json=encode_json)) for k, v in obj.items())
+        return dict((_asdict(k, encode_json=encode_json),
+                     _asdict(v, encode_json=encode_json)) for k, v in
+                    obj.items())
     elif isinstance(obj, Collection) and not isinstance(obj, str):
         return list(_asdict(v, encode_json=encode_json) for v in obj)
     else:

--- a/tests/entities.py
+++ b/tests/entities.py
@@ -16,7 +16,7 @@ from uuid import UUID
 from marshmallow import fields
 
 import dataclasses_json
-from dataclasses_json import (DataClassJsonMixin, dataclass_json, LetterCase, configured_dataclass_json)
+from dataclasses_json import (DataClassJsonMixin, dataclass_json, LetterCase)
 
 A = TypeVar('A')
 Id = NewType('Id', UUID)
@@ -186,7 +186,7 @@ class DataClassWithConfigHelper:
     id: float = field(metadata=dataclasses_json.config(encoder=str))
 
 
-@configured_dataclass_json(letter_case=LetterCase.CAMEL)
+@dataclass_json(letter_case=LetterCase.CAMEL)
 @dataclass
 class DataClassWithConfigDecorator:
     id_field: str


### PR DESCRIPTION
Addresses #128 

feat: make @dataclass_json take optional args and remove @configured_dataclass_json

BREAKING CHANGE: removes the `configured_dataclass_json` decorator in
favor of a unified `dataclass_json` decorator with optional args