### PR TITLE
Adding pascal casing as lettercase option

### DIFF
--- a/dataclasses_json/api.py
+++ b/dataclasses_json/api.py
@@ -6,7 +6,7 @@ from typing import (Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar,
                     Union)
 
 from marshmallow.fields import Field as MarshmallowField
-from stringcase import camelcase, snakecase, spinalcase
+from stringcase import camelcase, snakecase, spinalcase, pascalcase
 
 from dataclasses_json.core import (Json, _ExtendedEncoder, _asdict,
                                    _decode_dataclass)
@@ -22,6 +22,7 @@ class LetterCase(Enum):
     CAMEL = camelcase
     KEBAB = spinalcase
     SNAKE = snakecase
+    PASCAL = pascalcase
 
 
 def config(metadata: dict = None, *,

--- a/tests/test_letter_case.py
+++ b/tests/test_letter_case.py
@@ -35,6 +35,16 @@ class SnakeCasePerson:
 
 @dataclass_json
 @dataclass
+class PascalCasePerson:
+    given_name: str = field(
+        metadata={'dataclasses_json': {
+            'letter_case': LetterCase.PASCAL
+        }}
+    )
+
+
+@dataclass_json
+@dataclass
 class FieldNamePerson:
     given_name: str = field(metadata=config(field_name='givenName'))
 
@@ -60,6 +70,13 @@ class TestLetterCase:
     def test_snake_decode(self):
         assert SnakeCasePerson.from_json(
             '{"given_name": "Alice"}') == SnakeCasePerson('Alice')
+
+    def test_pascal_encode(self):
+        assert PascalCasePerson('Alice').to_json() == '{"GivenName": "Alice"}'
+
+    def test_pascal_decode(self):
+        assert PascalCasePerson.from_json(
+            '{"GivenName": "Alice"}') == PascalCasePerson('Alice')
 
     def test_field_name_encode(self):
         assert FieldNamePerson('Alice').to_json() == '{"givenName": "Alice"}'


### PR DESCRIPTION
Added `PASCAL` to LetterCase. This allows you to serialise/deserialise json such as `{"GivenName": "Alice"}`

Pascal casing is popular in .NET microservices (Newtonsoft JSON.NET uses it as a standard strategy).