### PR TITLE
Fix a readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ class ConfiguredSimpleExample:
     int_field: int
 
 ConfiguredSimpleExample(1).to_json()  # {"intField": 1}
-ConfiguredSimpleExample.from_json({"intField": 1})  # ConfiguredSimpleExample(1)
+ConfiguredSimpleExample.from_json('{"intField": 1}')  # ConfiguredSimpleExample(1)
 ```
 
 ## Supported types


### PR DESCRIPTION
`from_json` doesn't accept a dict, so I changed it to a string to match the above quickstart example.