### PR TITLE
Use caching to improve performance

### DIFF
--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -45,6 +45,7 @@ class _ExtendedEncoder(json.JSONEncoder):
         return result
 
 
+@lru_cache(maxsize=128)
 def _user_overrides(cls):
     confs = ['encoder', 'decoder', 'mm_field', 'letter_case']
     FieldOverride = namedtuple('FieldOverride', confs)

--- a/dataclasses_json/utils.py
+++ b/dataclasses_json/utils.py
@@ -1,6 +1,7 @@
 import inspect
 import sys
 from datetime import datetime, timezone
+from functools import lru_cache
 from typing import Collection, Mapping, Optional
 
 
@@ -62,6 +63,7 @@ def _isinstance_safe(o, t):
         return result
 
 
+@lru_cache(maxsize=128)
 def _issubclass_safe(cls, classinfo):
     try:
         return issubclass(cls, classinfo)


### PR DESCRIPTION
dataclasses-json is very slow when parsing lists of objects because it introspects the dataclasses every time. This pull request caches the slowest of those calls using python's built-in `lru_cache`, Reducing the decoding time for my test json from 21s to 2.1s. 

There are commits: With 56c3c9d the already failing test keeps failing, while the remainder of the tests passes. With cbe4d87 pytest fails on collecting tests cases due to some type being unhashable.