### PR TITLE
Fix a couple issues with api type hints

### DIFF
--- a/dataclasses_json/api.py
+++ b/dataclasses_json/api.py
@@ -117,7 +117,7 @@ class DataClassJsonMixin(abc.ABC):
                   infer_missing=False) -> A:
         return _decode_dataclass(cls, kvs, infer_missing)
 
-    def to_dict(self, encode_json=False):
+    def to_dict(self, encode_json=False) -> Dict[str, Json]:
         return _asdict(self, encode_json=encode_json)
 
     @classmethod

--- a/dataclasses_json/api.py
+++ b/dataclasses_json/api.py
@@ -26,8 +26,8 @@ class LetterCase(Enum):
 
 
 def config(metadata: dict = None, *,
-           encoder: callable = None,
-           decoder: callable = None,
+           encoder: Callable = None,
+           decoder: Callable = None,
            mm_field: MarshmallowField = None,
            letter_case: Callable[[str], str] = None,
            field_name: str = None) -> Dict[str, dict]:


### PR DESCRIPTION
I was excited to find out that https://github.com/lidatong/dataclasses-json/pull/150 was now available, but I ran into some issues when updating our projects.

Here are a few fixes for them:

1. Change callable to Callable (this could likely be improved further but I'm not too familiar with what should be the exact constraints)
2. Add type information to `DataClassJsonMixin.to_dict`