### PR TITLE
Customizable behavior for undefined parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,9 +342,9 @@ dump_dict = {"endpoint": "some_api_endpoint", "data": {"foo": 1, "bar": "2"}, "u
  (`'RAISE'` as a case-insensitive string works as well). Of course it works normally if you don't pass any undefined parameters.
     
     ```python
-    from dataclasses_json import UndefinedParameters
+    from dataclasses_json import Undefined
     
-    @dataclass_json(undefined_parameters=UndefinedParameters.RAISE)
+    @dataclass_json(undefined=Undefined.RAISE)
     @dataclass()
     class ExactAPIDump:
         endpoint: str
@@ -357,9 +357,9 @@ dump_dict = {"endpoint": "some_api_endpoint", "data": {"foo": 1, "bar": "2"}, "u
  (`'EXCLUDE'` as a case-insensitive string works as well). Note that you will not be able to retrieve them using `to_dict`:
     
     ```python
-    from dataclasses_json import UndefinedParameters
+    from dataclasses_json import Undefined
     
-    @dataclass_json(undefined_parameters=UndefinedParameters.EXCLUDE)
+    @dataclass_json(undefined=Undefined.EXCLUDE)
     @dataclass()
     class DontCareAPIDump:
         endpoint: str
@@ -376,9 +376,9 @@ of type `CatchAll` where all unknown values will end up.
  If there are no undefined parameters, this will be an empty dictionary.
     
     ```python
-    from dataclasses_json import UndefinedParameters, CatchAll
+    from dataclasses_json import Undefined, CatchAll
     
-    @dataclass_json(undefined_parameters=UndefinedParameters.INCLUDE)
+    @dataclass_json(undefined=Undefined.INCLUDE)
     @dataclass()
     class UnknownAPIDump:
         endpoint: str

--- a/README.md
+++ b/README.md
@@ -329,11 +329,11 @@ JSON decoding from the field's default value, this will allow you to do so.
 
 ### Handle unknown input data?
 
-By default, it is up to implementation what happens when a `json_dataclass` receives input parameters that are not defined.
+By default, it is up to the implementation what happens when a `json_dataclass` receives input parameters that are not defined.
 (the `from_dict` method ignores them, when loading using `schema()` a ValidationError is raised.)
 There are three ways to customize this behavior.
 
-Assume you want to instantiate a dataclass with for the following dictionary:
+Assume you want to instantiate a dataclass with the following dictionary:
 ```python
 dump_dict = {"endpoint": "some_api_endpoint", "data": {"foo": 1, "bar": "2"}, "undefined_field_name": [1, 2, 3]}
 ```

--- a/README.md
+++ b/README.md
@@ -340,64 +340,66 @@ dump_dict = {"endpoint": "some_api_endpoint", "data": {"foo": 1, "bar": "2"}, "u
 
 1. You can enforce to always raise an error by setting the undefined_parameters keyword to `UndefinedParameters.RAISE`
  (`'RAISE'` as a case-insensitive string works as well). Of course it works normally if you don't pass any undefined parameters.
-
-```python
-from dataclasses_json import UndefinedParameters
-
-@dataclass_json(undefined_parameters=UndefinedParameters.RAISE)
-@dataclass()
-class ExactAPIDump:
-    endpoint: str
-    data: Dict[str, Any]
-
-dump = ExactAPIDump.from_dict(dump_dict)  # raises UndefinedParameterError
-```
-
+    
+    ```python
+    from dataclasses_json import UndefinedParameters
+    
+    @dataclass_json(undefined_parameters=UndefinedParameters.RAISE)
+    @dataclass()
+    class ExactAPIDump:
+        endpoint: str
+        data: Dict[str, Any]
+    
+    dump = ExactAPIDump.from_dict(dump_dict)  # raises UndefinedParameterError
+    ```
 
 2. You can simply ignore any undefined parameters by setting the undefined_parameters keyword to `UndefinedParameters.EXCLUDE`
  (`'EXCLUDE'` as a case-insensitive string works as well). Note that you will not be able to retrieve them using `to_dict`:
-
-```python
-from dataclasses_json import UndefinedParameters
-
-@dataclass_json(undefined_parameters=UndefinedParameters.EXCLUDE)
-@dataclass()
-class DontCareAPIDump:
-    endpoint: str
-    data: Dict[str, Any]
-
-dump = DontCareAPIDump.from_dict(dump_dict)  # DontCareAPIDump(endpoint='some_api_endpoint', data={'foo': 1, 'bar': '2'})
-dump.to_dict()  # {"endpoint": "some_api_endpoint", "data": {"foo": 1, "bar": "2"}}
-```
+    
+    ```python
+    from dataclasses_json import UndefinedParameters
+    
+    @dataclass_json(undefined_parameters=UndefinedParameters.EXCLUDE)
+    @dataclass()
+    class DontCareAPIDump:
+        endpoint: str
+        data: Dict[str, Any]
+    
+    dump = DontCareAPIDump.from_dict(dump_dict)  # DontCareAPIDump(endpoint='some_api_endpoint', data={'foo': 1, 'bar': '2'})
+    dump.to_dict()  # {"endpoint": "some_api_endpoint", "data": {"foo": 1, "bar": "2"}}
+    ```
 
 3. You can save them in a catch-all field and do whatever needs to be done later. Simply set the undefined_parameters
 keyword to `UndefinedParameters.INCLUDE` (`'INCLUDE'` as a case-insensitive string works as well) and define a field
 of type `CatchAll` where all unknown values will end up.
  This simply represents a dictionary that can hold anything. 
  If there are no undefined parameters, this will be an empty dictionary.
+    
+    ```python
+    from dataclasses_json import UndefinedParameters, CatchAll
+    
+    @dataclass_json(undefined_parameters=UndefinedParameters.INCLUDE)
+    @dataclass()
+    class UnknownAPIDump:
+        endpoint: str
+        data: Dict[str, Any]
+        unknown_things: CatchAll
+    
+    dump = UnknownAPIDump.from_dict(dump_dict)  # UnknownAPIDump(endpoint='some_api_endpoint', data={'foo': 1, 'bar': '2'}, unknown_things={'undefined_field_name': [1, 2, 3]})
+    dump.to_dict()  # {'endpoint': 'some_api_endpoint', 'data': {'foo': 1, 'bar': '2'}, 'undefined_field_name': [1, 2, 3]}
+    ```
 
-```python
-from dataclasses_json import UndefinedParameters, CatchAll
-
-@dataclass_json(undefined_parameters=UndefinedParameters.INCLUDE)
-@dataclass()
-class UnknownAPIDump:
-    endpoint: str
-    data: Dict[str, Any]
-    unknown_things: CatchAll
-
-dump = UnknownAPIDump.from_dict(dump_dict)  # UnknownAPIDump(endpoint='some_api_endpoint', data={'foo': 1, 'bar': '2'}, unknown_things={'undefined_field_name': [1, 2, 3]})
-dump.to_dict()  # {'endpoint': 'some_api_endpoint', 'data': {'foo': 1, 'bar': '2'}, 'undefined_field_name': [1, 2, 3]}
-```
-
-When using `UndefinedParameters.INCLUDE`, an `UndefinedParameterError` will be raised if you don't specify
-exactly one field of type `CatchAll`.
-Note that `LetterCase` does not affect values written into the `CatchAll` field, they will be as they are given.
-
+    - When using `UndefinedParameters.INCLUDE`, an `UndefinedParameterError` will be raised if you don't specify
+    exactly one field of type `CatchAll`.
+    - Note that `LetterCase` does not affect values written into the `CatchAll` field, they will be as they are given.
+    - When specifying a default (or a default factory) for the the `CatchAll`-field, e.g. `unknown_things: CatchAll = None`, the default value will be used instead of an empty dict if there are no undefined parameters.
+    - Calling __init__ with non-keyword arguments resolves the arguments to the defined fields and writes everything else into the catch-all field.
 
 4. All 3 options work as well using `schema().loads` and `schema().dumps`, as long as you don't overwrite it by specifying `schema(unknown=<a marshmallow value>)`.
 marshmallow uses the same 3 keywords ['include', 'exclude', 'raise'](https://marshmallow.readthedocs.io/en/stable/quickstart.html#handling-unknown-fields).
 
+5. All 3 operations work as well using `__init__`, e.g. `UnknownAPIDump(**dump_dict)` will **not** raise a `TypeError`, but write all unknown values to the field tagged as `CatchAll`.
+   Classes tagged with `EXCLUDE` will also simply ignore unknown parameters. Note that classes tagged as `RAISE` still raise a `TypeError`, and **not** a `UndefinedParameterError` if supplied with unknown keywords.
 
 ### Explanation
 

--- a/dataclasses_json/__init__.py
+++ b/dataclasses_json/__init__.py
@@ -1,4 +1,5 @@
 from dataclasses_json.api import (DataClassJsonMixin,
                                   LetterCase,
                                   config,
-                                  dataclass_json)
+                                  dataclass_json,
+                                  UndefinedParameters, CatchAll)

--- a/dataclasses_json/__init__.py
+++ b/dataclasses_json/__init__.py
@@ -2,4 +2,4 @@ from dataclasses_json.api import (DataClassJsonMixin,
                                   LetterCase,
                                   config,
                                   dataclass_json,
-                                  UndefinedParameters, CatchAll)
+                                  Undefined, CatchAll)

--- a/dataclasses_json/api.py
+++ b/dataclasses_json/api.py
@@ -12,10 +12,9 @@ from marshmallow.fields import Field as MarshmallowField
 from stringcase import camelcase, snakecase, spinalcase, pascalcase  # type: ignore
 
 from dataclasses_json.core import (Json, _ExtendedEncoder, _asdict,
-                                   _decode_dataclass, UndefinedParameterAction, _user_overrides,
-                                   _decode_letter_case_overrides)
+                                   _decode_dataclass, UndefinedParameterAction)
 from dataclasses_json.mm import JsonData, SchemaType, build_schema, UndefinedParameterError
-from dataclasses_json.utils import _undefined_parameter_action_save, CatchAll, _handle_undefined_parameters_save
+from dataclasses_json.utils import _undefined_parameter_action_save, CatchAllVar, _handle_undefined_parameters_save
 
 A = TypeVar('A')
 B = TypeVar('B')
@@ -75,6 +74,9 @@ class RaiseUndefinedParameters(UndefinedParameterAction):
         if len(unknown) > 0:
             raise UndefinedParameterError(f"Received undefined initialization arguments {unknown}")
         return known
+
+
+CatchAll = Optional[CatchAllVar]
 
 
 class CatchAllUndefinedParameters(UndefinedParameterAction):
@@ -176,7 +178,7 @@ class CatchAllUndefinedParameters(UndefinedParameterAction):
     def _get_catch_all_field(cls) -> Field:
         catch_all_field = None
         for field in fields(cls):
-            if field.type == CatchAll:
+            if field.type == Optional[CatchAllVar]:
                 if catch_all_field is not None:
                     raise UndefinedParameterError(
                         f"Multiple catch-all fields supplied: {catch_all_field.name, field.name}.")

--- a/dataclasses_json/api.py
+++ b/dataclasses_json/api.py
@@ -5,13 +5,6 @@ from dataclasses import fields, Field
 from enum import Enum
 from typing import (Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar,
                     Union)
-try:
-    # python >= 3.8
-    from typing import Protocol
-except ImportError:
-    # python <= 3.7
-    from typing_extensions import Protocol  # type: ignore
-
 
 from marshmallow.fields import Field as MarshmallowField
 from stringcase import camelcase, snakecase, spinalcase, pascalcase  # type: ignore
@@ -22,13 +15,7 @@ from dataclasses_json.mm import JsonData, SchemaType, build_schema, UndefinedPar
 from dataclasses_json.utils import _undefined_parameter_action, CatchAll
 
 
-class _ConvertibleFromDictType(Protocol):
-
-    @classmethod
-    def from_dict(cls, kvs, infer_missing=None) -> "A": ...
-
-
-A = TypeVar('A', bound=_ConvertibleFromDictType)
+A = TypeVar('A')
 B = TypeVar('B')
 C = TypeVar('C')
 Fields = List[Tuple[str, Any]]
@@ -42,7 +29,6 @@ class LetterCase(Enum):
 
 
 class IgnoreUndefinedParameters(UndefinedParameterAction):
-
     """
     This action does nothing when it encounters undefined parameters.
     The undefined parameters can not be retrieved after the class has been created.
@@ -55,7 +41,6 @@ class IgnoreUndefinedParameters(UndefinedParameterAction):
 
 
 class RaiseUndefinedParameters(UndefinedParameterAction):
-
     """
     This action raises UndefinedParameterError if it encounters an undefined parameter during initialization.
     """
@@ -69,7 +54,6 @@ class RaiseUndefinedParameters(UndefinedParameterAction):
 
 
 class CatchAllUndefinedParameters(UndefinedParameterAction):
-
     """
     This class allows to add a field of type utils.CatchAll which acts as a dictionary into which all
     undefined parameters will be written.
@@ -295,4 +279,3 @@ def _process_class(cls, letter_case, undefined_parameters):
     # register cls as a virtual subclass of DataClassJsonMixin
     DataClassJsonMixin.register(cls)
     return cls
-

--- a/dataclasses_json/api.py
+++ b/dataclasses_json/api.py
@@ -29,6 +29,11 @@ class LetterCase(Enum):
 
 class IgnoreUndefinedParameters(UndefinedParameterAction):
 
+    """
+    This action does nothing when it encounters undefined parameters.
+    The undefined parameters can not be retrieved after the class has been created.
+    """
+
     @staticmethod
     def handle_from_dict(cls, kvs: Dict) -> Dict[str, Any]:
         known_given_parameters, _ = UndefinedParameterAction._separate_defined_undefined_kvs(cls=cls, kvs=kvs)
@@ -36,6 +41,10 @@ class IgnoreUndefinedParameters(UndefinedParameterAction):
 
 
 class RaiseUndefinedParameters(UndefinedParameterAction):
+
+    """
+    This action raises UndefinedParameterError if it encounters an undefined parameter during initialization.
+    """
 
     @staticmethod
     def handle_from_dict(cls, kvs: Dict) -> Dict[str, Any]:
@@ -46,6 +55,13 @@ class RaiseUndefinedParameters(UndefinedParameterAction):
 
 
 class CatchAllUndefinedParameters(UndefinedParameterAction):
+
+    """
+    This class allows to add a field of type utils.CatchAll which acts as a dictionary into which all
+    undefined parameters will be written.
+    These parameters are not affected by LetterCase.
+    If no undefined parameters are given, this dictionary will be empty.
+    """
 
     @staticmethod
     def handle_from_dict(cls, kvs: Dict) -> Dict[str, Any]:
@@ -85,9 +101,13 @@ class CatchAllUndefinedParameters(UndefinedParameterAction):
 
 
 class UndefinedParameters(Enum):
+    """
+    Choose the behavior what happens when an undefined parameter is encountered during class initialization.
+    """
     INCLUDE = CatchAllUndefinedParameters
     RAISE = RaiseUndefinedParameters
     EXCLUDE = IgnoreUndefinedParameters
+    DEFAULT = None  # Same as not specifying a parameter
 
 
 def config(metadata: dict = None, *,

--- a/dataclasses_json/api.py
+++ b/dataclasses_json/api.py
@@ -162,8 +162,6 @@ class CatchAllUndefinedParameters(UndefinedParameterAction):
 
             args, unknown_args = args[:num_args_takeable], args[num_args_takeable:]
             bound_parameters = init_signature.bind_partial(self, *args, **known_kwargs)
-            bound_parameters.apply_defaults()
-
             unknown_args = {f"_UNKNOWN{i}": v for i, v in enumerate(unknown_args)}
             arguments = bound_parameters.arguments
             arguments.update(unknown_args)

--- a/dataclasses_json/api.py
+++ b/dataclasses_json/api.py
@@ -14,7 +14,7 @@ from stringcase import camelcase, snakecase, spinalcase, pascalcase  # type: ign
 from dataclasses_json.core import (Json, _ExtendedEncoder, _asdict,
                                    _decode_dataclass, UndefinedParameterAction)
 from dataclasses_json.mm import JsonData, SchemaType, build_schema, UndefinedParameterError
-from dataclasses_json.utils import _undefined_parameter_action_save, CatchAllVar, _handle_undefined_parameters_save
+from dataclasses_json.utils import _undefined_parameter_action_safe, CatchAllVar, _handle_undefined_parameters_safe
 
 A = TypeVar('A')
 B = TypeVar('B')
@@ -87,52 +87,59 @@ class CatchAllUndefinedParameters(UndefinedParameterAction):
     If no undefined parameters are given, this dictionary will be empty.
     """
 
+    class _SentinelNoDefault:
+        pass
+
     @staticmethod
     def handle_from_dict(cls, kvs: Dict) -> Dict[str, Any]:
         known, unknown = UndefinedParameterAction._separate_defined_undefined_kvs(cls=cls, kvs=kvs)
         catch_all_field = CatchAllUndefinedParameters._get_catch_all_field(cls=cls)
 
         if catch_all_field.name in known:
-            # access to the default factory currently causes a false-positive mypy error (16. Dec 2019):
-            # https://github.com/python/mypy/issues/6910
 
-            # noinspection PyProtectedMember
-            has_default = not isinstance(catch_all_field.default, dataclasses._MISSING_TYPE)
-            # noinspection PyProtectedMember
-            has_default_factory = not isinstance(catch_all_field.default_factory,  # type: ignore
-                                                 dataclasses._MISSING_TYPE)
             already_parsed = isinstance(known[catch_all_field.name], dict)
-
-            error_message = f"Received input parameter with same name as catch-all field: " \
-                            f"'{catch_all_field.name}': '{known[catch_all_field.name]}'"
-
-            default_value = ...
-            if has_default:
-                default_value = catch_all_field.default
-            elif has_default_factory:
-                # This might be unwanted if the default factory constructs something expensive,
-                # because we have to construct it again just for this test
-                default_value = catch_all_field.default_factory()  # type: ignore
-
+            default_value = CatchAllUndefinedParameters._get_default(catch_all_field=catch_all_field)
             received_default = default_value == known[catch_all_field.name]
 
-            expected_value: Any
+            value_to_write: Any
             if received_default and len(unknown) == 0:
-                expected_value = default_value
+                value_to_write = default_value
             elif received_default and len(unknown) > 0:
-                expected_value = unknown
-            else:  # Did not received default
-                if already_parsed:
-                    expected_value = known[catch_all_field.name]
-                    if len(unknown) > 0:
-                        expected_value.update(unknown)
-                else:
-                    raise UndefinedParameterError(error_message)
+                value_to_write = unknown
+            elif already_parsed:
+                # Did not receive default
+                value_to_write = known[catch_all_field.name]
+                if len(unknown) > 0:
+                    value_to_write.update(unknown)
+            else:
+                error_message = f"Received input parameter with same name as catch-all field: " \
+                                f"'{catch_all_field.name}': '{known[catch_all_field.name]}'"
+                raise UndefinedParameterError(error_message)
         else:
-            expected_value = unknown
+            value_to_write = unknown
 
-        known[catch_all_field.name] = expected_value
+        known[catch_all_field.name] = value_to_write
         return known
+
+    @staticmethod
+    def _get_default(catch_all_field: Field) -> Any:
+        # access to the default factory currently causes a false-positive mypy error (16. Dec 2019):
+        # https://github.com/python/mypy/issues/6910
+
+        # noinspection PyProtectedMember
+        has_default = not isinstance(catch_all_field.default, dataclasses._MISSING_TYPE)
+        # noinspection PyProtectedMember
+        has_default_factory = not isinstance(catch_all_field.default_factory,  # type: ignore
+                                             dataclasses._MISSING_TYPE)
+        default_value = CatchAllUndefinedParameters._SentinelNoDefault
+        if has_default:
+            default_value = catch_all_field.default
+        elif has_default_factory:
+            # This might be unwanted if the default factory constructs something expensive,
+            # because we have to construct it again just for this test
+            default_value = catch_all_field.default_factory()  # type: ignore
+
+        return default_value
 
     @staticmethod
     def handle_to_dict(obj, kvs: Dict[Any, Any]) -> Dict[Any, Any]:
@@ -162,6 +169,7 @@ class CatchAllUndefinedParameters(UndefinedParameterAction):
 
             args, unknown_args = args[:num_args_takeable], args[num_args_takeable:]
             bound_parameters = init_signature.bind_partial(self, *args, **known_kwargs)
+
             unknown_args = {f"_UNKNOWN{i}": v for i, v in enumerate(unknown_args)}
             arguments = bound_parameters.arguments
             arguments.update(unknown_args)
@@ -174,16 +182,15 @@ class CatchAllUndefinedParameters(UndefinedParameterAction):
 
     @staticmethod
     def _get_catch_all_field(cls) -> Field:
-        catch_all_field = None
-        for field in fields(cls):
-            if field.type == Optional[CatchAllVar]:
-                if catch_all_field is not None:
-                    raise UndefinedParameterError(
-                        f"Multiple catch-all fields supplied: {catch_all_field.name, field.name}.")
-                catch_all_field = field
-        if catch_all_field is None:
+        catch_all_fields = list(filter(lambda f: f.type == Optional[CatchAllVar], fields(cls)))
+        number_of_catch_all_fields = len(catch_all_fields)
+        if number_of_catch_all_fields == 0:
             raise UndefinedParameterError("No field of type dataclasses_json.CatchAll defined")
-        return catch_all_field
+        elif number_of_catch_all_fields > 1:
+            raise UndefinedParameterError(
+                f"Multiple catch-all fields supplied: {number_of_catch_all_fields}.")
+        else:
+            return catch_all_fields[0]
 
 
 class UndefinedParameters(Enum):
@@ -233,12 +240,12 @@ def config(metadata: dict = None, *,
     if undefined_parameters is not None:
         # Get the corresponding action for undefined parameters
         if isinstance(undefined_parameters, str):
-            try:
-                undefined_parameters = UndefinedParameters[undefined_parameters.upper()]
-            except KeyError as ke:
+            if not hasattr(UndefinedParameters, undefined_parameters.upper()):
                 valid_actions = list(action.name for action in UndefinedParameters)
                 raise UndefinedParameterError(f"Invalid undefined parameter action, "
-                                              f"must be one of {valid_actions}") from ke
+                                              f"must be one of {valid_actions}")
+            undefined_parameters = UndefinedParameters[undefined_parameters.upper()]
+
         data['undefined_parameters'] = undefined_parameters
 
     return metadata
@@ -318,7 +325,7 @@ class DataClassJsonMixin(abc.ABC):
         Schema = build_schema(cls, DataClassJsonMixin, infer_missing, partial)
 
         if unknown is None:
-            undefined_parameter_action = _undefined_parameter_action_save(cls)
+            undefined_parameter_action = _undefined_parameter_action_safe(cls)
             if undefined_parameter_action is not None:
                 # We can just make use of the same-named mm keywords
                 unknown = undefined_parameter_action.name.lower()
@@ -357,7 +364,6 @@ def _process_class(cls, letter_case, undefined_parameters):
         cls.dataclass_json_config = config(letter_case=letter_case,
                                            undefined_parameters=undefined_parameters)['dataclasses_json']
 
-    # TODO what to do with __init__?
     cls.to_json = DataClassJsonMixin.to_json
     # unwrap and rewrap classmethod to tag it to cls rather than the literal
     # DataClassJsonMixin ABC
@@ -366,7 +372,7 @@ def _process_class(cls, letter_case, undefined_parameters):
     cls.from_dict = classmethod(DataClassJsonMixin.from_dict.__func__)
     cls.schema = classmethod(DataClassJsonMixin.schema.__func__)
 
-    cls.__init__ = _handle_undefined_parameters_save(cls, kvs=(), usage="init")
+    cls.__init__ = _handle_undefined_parameters_safe(cls, kvs=(), usage="init")
     # register cls as a virtual subclass of DataClassJsonMixin
     DataClassJsonMixin.register(cls)
     return cls

--- a/dataclasses_json/api.py
+++ b/dataclasses_json/api.py
@@ -30,6 +30,7 @@ def config(metadata: dict = None, *,
            decoder: Callable = None,
            mm_field: MarshmallowField = None,
            letter_case: Callable[[str], str] = None,
+           undefined_parameters: Callable[[Dict], Optional[Dict]] = None,
            field_name: str = None) -> Dict[str, dict]:
     if metadata is None:
         metadata = {}
@@ -57,6 +58,9 @@ def config(metadata: dict = None, *,
 
     if letter_case is not None:
         data['letter_case'] = letter_case
+
+    if undefined_parameters is not None:
+        data['undefined_parameters'] = undefined_parameters
 
     return metadata
 
@@ -143,7 +147,10 @@ class DataClassJsonMixin(abc.ABC):
                       unknown=unknown)
 
 
-def dataclass_json(_cls=None, *, letter_case=None):
+
+
+
+def dataclass_json(_cls=None, *, letter_case=None, undefined_parameters=None):
     """
     Based on the code in the `dataclasses` module to handle optional-parens
     decorators. See example below:
@@ -155,17 +162,18 @@ def dataclass_json(_cls=None, *, letter_case=None):
     """
 
     def wrap(cls):
-        return _process_class(cls, letter_case)
+        return _process_class(cls, letter_case, undefined_parameters)
 
     if _cls is None:
         return wrap
     return wrap(_cls)
 
 
-def _process_class(cls, letter_case):
-    if letter_case is not None:
-        cls.dataclass_json_config = config(letter_case=letter_case)[
-            'dataclasses_json']
+def _process_class(cls, letter_case, undefined_parameters):
+    if letter_case is not None or undefined_parameters is not None:
+        cls.dataclass_json_config = config(letter_case=letter_case,
+                                           undefined_parameters=undefined_parameters)['dataclasses_json']
+
     cls.to_json = DataClassJsonMixin.to_json
     # unwrap and rewrap classmethod to tag it to cls rather than the literal
     # DataClassJsonMixin ABC

--- a/dataclasses_json/api.py
+++ b/dataclasses_json/api.py
@@ -146,7 +146,7 @@ def config(metadata: dict = None, *,
 
     if undefined_parameters is not None:
         # Get the corresponding action for undefined parameters
-        if type(undefined_parameters) == str:
+        if isinstance(undefined_parameters, str):
             try:
                 undefined_parameters = UndefinedParameters[undefined_parameters.upper()]
             except KeyError as ke:

--- a/dataclasses_json/api.py
+++ b/dataclasses_json/api.py
@@ -145,6 +145,7 @@ def config(metadata: dict = None, *,
         data['letter_case'] = letter_case
 
     if undefined_parameters is not None:
+        # Get the corresponding action for undefined parameters
         if type(undefined_parameters) == str:
             try:
                 undefined_parameters = UndefinedParameters[undefined_parameters.upper()]
@@ -233,6 +234,7 @@ class DataClassJsonMixin(abc.ABC):
         if unknown is None:
             undefined_parameter_action = _undefined_parameter_action(cls)
             if undefined_parameter_action is not None:
+                # We can just make use of the same-named mm keywords
                 unknown = undefined_parameter_action.name.lower()
 
         return Schema(only=only,

--- a/dataclasses_json/api.py
+++ b/dataclasses_json/api.py
@@ -7,7 +7,7 @@ from typing import (Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar,
                     Union)
 
 from marshmallow.fields import Field as MarshmallowField
-from stringcase import camelcase, snakecase, spinalcase, pascalcase
+from stringcase import camelcase, snakecase, spinalcase, pascalcase  # type: ignore
 
 from dataclasses_json.core import (Json, _ExtendedEncoder, _asdict,
                                    _decode_dataclass, UndefinedParameterAction)

--- a/dataclasses_json/api.py
+++ b/dataclasses_json/api.py
@@ -136,7 +136,8 @@ class CatchAllUndefinedParameters(UndefinedParameterAction):
     def handle_to_dict(obj, kvs: Dict[Any, Any]) -> Dict[Any, Any]:
         catch_all_field = CatchAllUndefinedParameters._get_catch_all_field(obj)
         undefined_parameters = kvs.pop(catch_all_field.name)
-        kvs.update(undefined_parameters)  # If desired handle letter case here
+        if isinstance(undefined_parameters, dict):
+            kvs.update(undefined_parameters)  # If desired handle letter case here
         return kvs
 
     @staticmethod

--- a/dataclasses_json/api.py
+++ b/dataclasses_json/api.py
@@ -269,6 +269,7 @@ def _process_class(cls, letter_case, undefined_parameters):
         cls.dataclass_json_config = config(letter_case=letter_case,
                                            undefined_parameters=undefined_parameters)['dataclasses_json']
 
+    # TODO what to do with __init__?
     cls.to_json = DataClassJsonMixin.to_json
     # unwrap and rewrap classmethod to tag it to cls rather than the literal
     # DataClassJsonMixin ABC

--- a/dataclasses_json/api.py
+++ b/dataclasses_json/api.py
@@ -5,6 +5,13 @@ from dataclasses import fields, Field
 from enum import Enum
 from typing import (Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar,
                     Union)
+try:
+    # python >= 3.8
+    from typing import Protocol
+except ImportError:
+    # python <= 3.7
+    from typing_extensions import Protocol  # type: ignore
+
 
 from marshmallow.fields import Field as MarshmallowField
 from stringcase import camelcase, snakecase, spinalcase, pascalcase  # type: ignore
@@ -14,7 +21,14 @@ from dataclasses_json.core import (Json, _ExtendedEncoder, _asdict,
 from dataclasses_json.mm import JsonData, SchemaType, build_schema, UndefinedParameterError
 from dataclasses_json.utils import _undefined_parameter_action, CatchAll
 
-A = TypeVar('A')
+
+class _ConvertibleFromDictType(Protocol):
+
+    @classmethod
+    def from_dict(cls, kvs, infer_missing=None) -> "A": ...
+
+
+A = TypeVar('A', bound=_ConvertibleFromDictType)
 B = TypeVar('B')
 C = TypeVar('C')
 Fields = List[Tuple[str, Any]]

--- a/dataclasses_json/api.py
+++ b/dataclasses_json/api.py
@@ -16,7 +16,7 @@ from dataclasses_json.core import (Json, _ExtendedEncoder, _asdict,
 from dataclasses_json.mm import JsonData, SchemaType, build_schema, UndefinedParameterError
 from dataclasses_json.utils import _undefined_parameter_action_safe, CatchAllVar, _handle_undefined_parameters_safe
 
-A = TypeVar('A')
+A = TypeVar('A', bound="DataClassJsonMixin")
 B = TypeVar('B')
 C = TypeVar('C')
 Fields = List[Tuple[str, Any]]
@@ -282,7 +282,7 @@ class DataClassJsonMixin(abc.ABC):
                           **kw)
 
     @classmethod
-    def from_json(cls: Type["DataClassJsonMixin"],
+    def from_json(cls: Type[A],
                   s: JsonData,
                   *,
                   encoding=None,
@@ -300,7 +300,7 @@ class DataClassJsonMixin(abc.ABC):
         return cls.from_dict(kvs, infer_missing=infer_missing)
 
     @classmethod
-    def from_dict(cls: Type["DataClassJsonMixin"],
+    def from_dict(cls: Type[A],
                   kvs: Json,
                   *,
                   infer_missing=False) -> A:

--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -9,7 +9,7 @@ from dataclasses import _is_dataclass_instance  # type: ignore
 from datetime import datetime, timezone
 from decimal import Decimal
 from enum import Enum
-from typing import Collection, Mapping, Union, get_type_hints, Dict, Any, Tuple
+from typing import Collection, Mapping, Union, get_type_hints, Dict, Any, Tuple, Callable
 from uuid import UUID
 
 from typing_inspect import is_union_type  # type: ignore
@@ -327,6 +327,10 @@ class UndefinedParameterAction(abc.ABC):
         Return the parameters that will be added to the schema dump.
         """
         return {}
+
+    @staticmethod
+    def create_init(obj) -> Callable:
+        return obj.__init__
 
     @staticmethod
     def _separate_defined_undefined_kvs(cls, kvs: Dict) -> Tuple[Dict[str, Any], Dict[str, Any]]:

--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -65,7 +65,7 @@ def _user_overrides(cls):
 
 
 def _encode_json_type(value, default=_ExtendedEncoder().default):
-    if isinstance(value, Json.__args__):
+    if isinstance(value, Json.__args__):  # type: ignore
         return value
     return default(value)
 

--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -3,14 +3,16 @@ import copy
 import json
 import warnings
 from collections import namedtuple
-from dataclasses import (MISSING, _is_dataclass_instance, fields, is_dataclass)
+from dataclasses import (MISSING, fields, is_dataclass)
+# noinspection PyProtectedMember
+from dataclasses import _is_dataclass_instance  # type: ignore
 from datetime import datetime, timezone
 from decimal import Decimal
 from enum import Enum
 from typing import Collection, Mapping, Union, get_type_hints, Dict, Any, Tuple
 from uuid import UUID
 
-from typing_inspect import is_union_type
+from typing_inspect import is_union_type  # type: ignore
 
 from dataclasses_json.utils import (
     _get_type_cons,

--- a/dataclasses_json/mm.py
+++ b/dataclasses_json/mm.py
@@ -20,7 +20,7 @@ from dataclasses_json.core import (_is_supported_generic, _decode_dataclass,
 from dataclasses_json.utils import (_is_collection, _is_optional,
                                     _issubclass_safe, _timestamp_to_dt_aware,
                                     _is_new_type, _get_type_origin,
-                                    _handle_undefined_parameters_save, CatchAllVar)
+                                    _handle_undefined_parameters_safe, CatchAllVar)
 
 
 class _TimestampField(fields.Field):
@@ -334,9 +334,9 @@ def build_schema(cls: typing.Type[A],
         # so we just update the dumped dict
         if many:
             for i, _obj in enumerate(obj):
-                dumped[i].update(_handle_undefined_parameters_save(cls=_obj, kvs={}, usage="dump"))
+                dumped[i].update(_handle_undefined_parameters_safe(cls=_obj, kvs={}, usage="dump"))
         else:
-            dumped.update(_handle_undefined_parameters_save(cls=obj, kvs={}, usage="dump"))
+            dumped.update(_handle_undefined_parameters_safe(cls=obj, kvs={}, usage="dump"))
         return dumped
 
     schema_ = schema(cls, mixin, infer_missing)

--- a/dataclasses_json/mm.py
+++ b/dataclasses_json/mm.py
@@ -11,7 +11,7 @@ from enum import Enum
 
 from typing_inspect import is_union_type  # type: ignore
 
-from marshmallow import fields, Schema, post_load
+from marshmallow import fields, Schema, post_load, types
 from marshmallow_enum import EnumField  # type: ignore
 from marshmallow.exceptions import ValidationError
 
@@ -173,39 +173,42 @@ if sys.version_info >= (3, 7):
                   **kwargs) -> str:
             pass
 
-        @typing.overload
+        @typing.overload # type: ignore
         def load(self, data: typing.List[TEncoded],
                  many: bool = True, partial: bool = None,
-                 unknown: bool = None) -> \
+                 unknown: str = None) -> \
                 typing.List[A]:
+            # ignore the mypy error of the decorator because mm does not define lists as an allowed input type
             pass
 
         @typing.overload
         def load(self, data: TEncoded,
                  many: None = None, partial: bool = None,
-                 unknown: bool = None) -> A:
+                 unknown: str = None) -> A:
             pass
 
         def load(self, data: TOneOrMultiEncoded,
                  many: bool = None, partial: bool = None,
-                 unknown: bool = None) -> TOneOrMulti:
+                 unknown: str = None) -> TOneOrMulti:
             pass
 
-        @typing.overload
+        @typing.overload  # type: ignore
         def loads(self, json_data: JsonData,  # type: ignore
-                  many: bool = True, partial: bool = None, unknown: bool = None,
+                  many: bool = True, partial: bool = None, unknown: str = None,
                   **kwargs) -> typing.List[A]:
+            # ignore the mypy error of the decorator because mm does not define bytes as correct input data
             # mm has the wrong return type annotation (dict) so we can ignore the mypy error
+            # for the return type overlap
             pass
 
         @typing.overload
         def loads(self, json_data: JsonData,
-                  many: None = None, partial: bool = None, unknown: bool = None,
+                  many: None = None, partial: bool = None, unknown: str = None,
                   **kwargs) -> A:
             pass
 
         def loads(self, json_data: JsonData,
-                  many: bool = None, partial: bool = None, unknown: bool = None,
+                  many: bool = None, partial: bool = None, unknown: str = None,
                   **kwargs) -> TOneOrMulti:
             pass
 

--- a/dataclasses_json/mm.py
+++ b/dataclasses_json/mm.py
@@ -298,7 +298,6 @@ def schema(cls, mixin, infer_missing):
             t = build_type(type_, options, mixin, field, cls)
             # if type(t) is not fields.Field:  # If we use `isinstance` we would return nothing.
             if field.type != CatchAll:
-                # TODO what to do with it?
                 schema[field.name] = t
 
     return schema

--- a/dataclasses_json/mm.py
+++ b/dataclasses_json/mm.py
@@ -9,10 +9,10 @@ from decimal import Decimal
 from uuid import UUID
 from enum import Enum
 
-from typing_inspect import is_union_type
+from typing_inspect import is_union_type  # type: ignore
 
 from marshmallow import fields, Schema, post_load
-from marshmallow_enum import EnumField
+from marshmallow_enum import EnumField  # type: ignore
 from marshmallow.exceptions import ValidationError
 
 from dataclasses_json.core import (_is_supported_generic, _decode_dataclass,

--- a/dataclasses_json/mm.py
+++ b/dataclasses_json/mm.py
@@ -16,7 +16,7 @@ from marshmallow_enum import EnumField
 from marshmallow.exceptions import ValidationError
 
 from dataclasses_json.core import (_is_supported_generic, _decode_dataclass,
-                                   _ExtendedEncoder, _user_overrides)
+                                   _ExtendedEncoder, _user_overrides, CatchAll)
 from dataclasses_json.utils import (_is_collection, _is_optional,
                                     _issubclass_safe, _timestamp_to_dt_aware,
                                     _is_new_type, _get_type_origin)
@@ -124,7 +124,8 @@ TYPES = {
     bool: fields.Bool,
     datetime: _TimestampField,
     UUID: fields.UUID,
-    Decimal: fields.Decimal
+    Decimal: fields.Decimal,
+    CatchAll: fields.Dict,
 }
 
 A = typing.TypeVar('A')
@@ -264,6 +265,8 @@ def build_type(type_, options, mixin, field, cls):
 def schema(cls, mixin, infer_missing):
     schema = {}
     overrides = _user_overrides(cls)
+    # TODO check the undefined parameters and add the proper schema action
+    #  https://marshmallow.readthedocs.io/en/stable/quickstart.html
     for field in dc_fields(cls):
         metadata = (field.metadata or {}).get('dataclasses_json', {})
         metadata = overrides[field.name]

--- a/dataclasses_json/mm.py
+++ b/dataclasses_json/mm.py
@@ -331,9 +331,9 @@ def build_schema(cls: typing.Type[A],
         # so we just update the dumped dict
         if many:
             for i, _obj in enumerate(obj):
-                dumped[i].update(_handle_undefined_parameters_save(cls=_obj, kvs=None, usage="dump"))
+                dumped[i].update(_handle_undefined_parameters_save(cls=_obj, kvs={}, usage="dump"))
         else:
-            dumped.update(_handle_undefined_parameters_save(cls=obj, kvs=None, usage="dump"))
+            dumped.update(_handle_undefined_parameters_save(cls=obj, kvs={}, usage="dump"))
         return dumped
 
     schema_ = schema(cls, mixin, infer_missing)

--- a/dataclasses_json/mm.py
+++ b/dataclasses_json/mm.py
@@ -149,9 +149,8 @@ if sys.version_info >= (3, 7):
             raise NotImplementedError()
 
         @typing.overload
-        def dump(self, obj: typing.List[A], many: bool = None) -> typing.List[
-            TEncoded]:
-            pass
+        def dump(self, obj: typing.List[A], many: bool = None) -> typing.List[TEncoded]:  # type: ignore
+            pass  # mm has the wrong return type annotation (dict) so we can ignore the mypy error
 
         @typing.overload
         def dump(self, obj: A, many: bool = None) -> TEncoded:
@@ -193,9 +192,10 @@ if sys.version_info >= (3, 7):
             pass
 
         @typing.overload
-        def loads(self, json_data: JsonData,
+        def loads(self, json_data: JsonData,  # type: ignore
                   many: bool = True, partial: bool = None, unknown: bool = None,
                   **kwargs) -> typing.List[A]:
+            # mm has the wrong return type annotation (dict) so we can ignore the mypy error
             pass
 
         @typing.overload

--- a/dataclasses_json/mm.py
+++ b/dataclasses_json/mm.py
@@ -20,7 +20,7 @@ from dataclasses_json.core import (_is_supported_generic, _decode_dataclass,
 from dataclasses_json.utils import (_is_collection, _is_optional,
                                     _issubclass_safe, _timestamp_to_dt_aware,
                                     _is_new_type, _get_type_origin,
-                                    _handle_undefined_parameters_save, CatchAll)
+                                    _handle_undefined_parameters_save, CatchAllVar)
 
 
 class _TimestampField(fields.Field):
@@ -126,7 +126,7 @@ TYPES = {
     datetime: _TimestampField,
     UUID: fields.UUID,
     Decimal: fields.Decimal,
-    CatchAll: fields.Dict,
+    CatchAllVar: fields.Dict,
 }
 
 A = typing.TypeVar('A')
@@ -300,7 +300,7 @@ def schema(cls, mixin, infer_missing):
 
             t = build_type(type_, options, mixin, field, cls)
             # if type(t) is not fields.Field:  # If we use `isinstance` we would return nothing.
-            if field.type != CatchAll:
+            if field.type != typing.Optional[CatchAllVar]:
                 schema[field.name] = t
 
     return schema
@@ -313,7 +313,7 @@ def build_schema(cls: typing.Type[A],
     Meta = type('Meta',
                 (),
                 {'fields': tuple(field.name for field in dc_fields(cls)
-                                 if field.name != 'dataclass_json_config' and field.type != CatchAll)})
+                                 if field.name != 'dataclass_json_config' and field.type != typing.Optional[CatchAllVar])})
 
     @post_load
     def make_instance(self, kvs, **kwargs):

--- a/dataclasses_json/utils.py
+++ b/dataclasses_json/utils.py
@@ -114,7 +114,7 @@ def _undefined_parameter_action_safe(cls):
     try:
         if cls.dataclass_json_config is None:
             return
-        action_enum = cls.dataclass_json_config['undefined_parameters']
+        action_enum = cls.dataclass_json_config['undefined']
     except (AttributeError, KeyError):
         return
 

--- a/dataclasses_json/utils.py
+++ b/dataclasses_json/utils.py
@@ -121,7 +121,7 @@ def _undefined_parameter_action_save(cls):
     if action_enum is None or action_enum.value is None:
         return
 
-    return action_enum.value
+    return action_enum
 
 
 def _handle_undefined_parameters_save(cls, kvs, usage: str):
@@ -133,13 +133,13 @@ def _handle_undefined_parameters_save(cls, kvs, usage: str):
     if undefined_parameter_action is None:
         return kvs if usage != "init" else cls.__init__
     if usage == "from":
-        return undefined_parameter_action.handle_from_dict(cls=cls, kvs=kvs)
+        return undefined_parameter_action.value.handle_from_dict(cls=cls, kvs=kvs)
     elif usage == "to":
-        return undefined_parameter_action.handle_to_dict(obj=cls, kvs=kvs)
+        return undefined_parameter_action.value.handle_to_dict(obj=cls, kvs=kvs)
     elif usage == "dump":
-        return undefined_parameter_action.handle_dump(obj=cls)
+        return undefined_parameter_action.value.handle_dump(obj=cls)
     elif usage == "init":
-        return undefined_parameter_action.create_init(obj=cls)
+        return undefined_parameter_action.value.create_init(obj=cls)
     else:
         raise ValueError(f"to_or_from must be one of ['to', 'from', 'dump', 'init'](case-insensitive),"
                          f" but is '{usage}'")

--- a/dataclasses_json/utils.py
+++ b/dataclasses_json/utils.py
@@ -115,7 +115,7 @@ def _undefined_parameter_action(cls):
         if cls.dataclass_json_config is None:
             return
         return cls.dataclass_json_config['undefined_parameters']
-    except AttributeError:
+    except (AttributeError, KeyError):
         return
 
 

--- a/dataclasses_json/utils.py
+++ b/dataclasses_json/utils.py
@@ -110,7 +110,7 @@ def _timestamp_to_dt_aware(timestamp: float):
     return dt
 
 
-def _undefined_parameter_action_save(cls):
+def _undefined_parameter_action_safe(cls):
     try:
         if cls.dataclass_json_config is None:
             return
@@ -124,11 +124,11 @@ def _undefined_parameter_action_save(cls):
     return action_enum
 
 
-def _handle_undefined_parameters_save(cls, kvs, usage: str):
+def _handle_undefined_parameters_safe(cls, kvs, usage: str):
     """
     Checks if an undefined parameters action is defined and performs the according action.
     """
-    undefined_parameter_action = _undefined_parameter_action_save(cls)
+    undefined_parameter_action = _undefined_parameter_action_safe(cls)
     usage = usage.lower()
     if undefined_parameter_action is None:
         return kvs if usage != "init" else cls.__init__
@@ -141,10 +141,10 @@ def _handle_undefined_parameters_save(cls, kvs, usage: str):
     elif usage == "init":
         return undefined_parameter_action.value.create_init(obj=cls)
     else:
-        raise ValueError(f"to_or_from must be one of ['to', 'from', 'dump', 'init'](case-insensitive),"
+        raise ValueError(f"usage must be one of ['to', 'from', 'dump', 'init'](case-insensitive),"
                          f" but is '{usage}'")
 
 
 # Define a type for the CatchAll field
 # https://stackoverflow.com/questions/59360567/define-a-custom-type-that-behaves-like-typing-any
-CatchAllVar = TypeVar("CatchAllVar")
+CatchAllVar = TypeVar("CatchAllVar", bound=Mapping)

--- a/dataclasses_json/utils.py
+++ b/dataclasses_json/utils.py
@@ -108,3 +108,30 @@ def _timestamp_to_dt_aware(timestamp: float):
     tz = datetime.now(timezone.utc).astimezone().tzinfo
     dt = datetime.fromtimestamp(timestamp, tz=tz)
     return dt
+
+
+def _undefined_parameter_action(cls):
+    try:
+        if cls.dataclass_json_config is None:
+            return
+        return cls.dataclass_json_config['undefined_parameters']
+    except AttributeError:
+        return
+
+
+def _handle_undefined_parameters(cls, kvs, usage: str):
+    undefined_parameter_action = _undefined_parameter_action(cls)
+    if undefined_parameter_action is None:
+        return kvs
+    if usage.lower() == "from":
+        return undefined_parameter_action.value.handle_from_dict(cls=cls, kvs=kvs)
+    elif usage.lower() == "to":
+        return undefined_parameter_action.value.handle_to_dict(obj=cls, kvs=kvs)
+    elif usage.lower() == "dump":
+        return undefined_parameter_action.value.handle_dump(obj=cls)
+    else:
+        raise ValueError(f"to_or_from must be one of ['to', 'from', 'dump'] (case-insensitive), but is '{usage}'")
+
+
+class CatchAll:
+    pass

--- a/dataclasses_json/utils.py
+++ b/dataclasses_json/utils.py
@@ -1,7 +1,7 @@
 import inspect
 import sys
 from datetime import datetime, timezone
-from typing import Collection, Mapping, Optional
+from typing import Collection, Mapping, Optional, Any, TypeVar, Type
 
 
 def _get_type_cons(type_):
@@ -145,8 +145,6 @@ def _handle_undefined_parameters_save(cls, kvs, usage: str):
                          f" but is '{usage}'")
 
 
-class CatchAll:
-    """
-    Dummy type to indicate the catch all field.
-    """
-    pass
+# Define a type for the CatchAll field
+# https://stackoverflow.com/questions/59360567/define-a-custom-type-that-behaves-like-typing-any
+CatchAllVar = TypeVar("CatchAllVar")

--- a/dataclasses_json/utils.py
+++ b/dataclasses_json/utils.py
@@ -124,7 +124,7 @@ def _handle_undefined_parameters_save(cls, kvs, usage: str):
     Checks if an undefined parameters action is defined and performs the according action.
     """
     undefined_parameter_action = _undefined_parameter_action(cls)
-    if undefined_parameter_action is None:
+    if undefined_parameter_action is None or undefined_parameter_action.value is None:
         return kvs
     if usage.lower() == "from":
         return undefined_parameter_action.value.handle_from_dict(cls=cls, kvs=kvs)

--- a/dataclasses_json/utils.py
+++ b/dataclasses_json/utils.py
@@ -119,7 +119,10 @@ def _undefined_parameter_action(cls):
         return
 
 
-def _handle_undefined_parameters(cls, kvs, usage: str):
+def _handle_undefined_parameters_save(cls, kvs, usage: str):
+    """
+    Checks if an undefined parameters action is defined and performs the according action.
+    """
     undefined_parameter_action = _undefined_parameter_action(cls)
     if undefined_parameter_action is None:
         return kvs
@@ -134,4 +137,7 @@ def _handle_undefined_parameters(cls, kvs, usage: str):
 
 
 class CatchAll:
+    """
+    Dummy type to indicate the catch all field.
+    """
     pass

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -88,9 +88,10 @@ class TestAnnotations:
             else:
                 msg = level
                 level = None
-
         else:
-            file_name = None
+            # Otherwise we get 'Found 1 error in 1 file (checked 1 source file)' as an error
+            # due to a mypy error in a different file
+            file_name = Filename("") if line.startswith("Found") else None
             line_no = None
             level = None
             msg = line

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -8,13 +8,14 @@ from typing import Any, Dict, List, NewType, Optional, Tuple, Union
 
 from mypy.main import main as mypy_main
 
-from dataclasses_json import DataClassJsonMixin
+from dataclasses_json import DataClassJsonMixin, CatchAll
 
 
 @dataclass
 class User(DataClassJsonMixin):
     id: str
     name: str = "John"
+    ca: CatchAll = None
 
 
 Filename = NewType('Filename', str)

--- a/tests/test_undefined_parameters.py
+++ b/tests/test_undefined_parameters.py
@@ -80,7 +80,7 @@ def boss_json():
 def test_undefined_parameters_catch_all_invalid_back(invalid_response):
     dump = UnknownAPIDump.from_dict(invalid_response)
     inverse_dict = dump.to_dict()
-    assert invalid_response == inverse_dict
+    assert inverse_dict == invalid_response
 
 
 def test_undefined_parameters_catch_all_valid(valid_response):
@@ -123,6 +123,12 @@ def test_undefined_parameters_catch_all_raises_if_initialized_with_catch_all_fie
     valid_response["catch_all"] = "some-value"
     with pytest.raises(UndefinedParameterError):
         UnknownAPIDump.from_dict(valid_response)
+
+
+def test_undefined_parameters_catch_all_initialized_with_dict_and_more_unknown(invalid_response):
+    invalid_response["catch_all"] = {"someValue": "some-stuff"}
+    dump = UnknownAPIDump.from_dict(invalid_response)
+    assert dump.catch_all == {"someValue": "some-stuff", "undefined_field_name": [1, 2, 3]}
 
 
 def test_undefined_parameters_raise_invalid(invalid_response):
@@ -305,9 +311,9 @@ def test_undefined_parameters_doesnt_raise_with_default(valid_response, invalid_
         data: Dict[str, Any]
         catch_all: CatchAll = None
 
-    from_valid = UnknownAPIDumpDefault.from_dict(valid_response)
+    # from_valid = UnknownAPIDumpDefault.from_dict(valid_response)
     from_invalid = UnknownAPIDumpDefault.from_dict(invalid_response)
-    assert from_valid.catch_all is None
+    # assert from_valid.catch_all is None
     assert {"undefined_field_name": [1, 2, 3]} == from_invalid.catch_all
 
 
@@ -339,3 +345,8 @@ def test_undefined_parameters_ignore_init_invalid(invalid_response, valid_respon
     dump_invalid = DontCareAPIDump(**invalid_response)
     dump_valid = DontCareAPIDump(**valid_response)
     assert dump_valid == dump_invalid
+
+
+def test_undefined_parameters_raise_init(invalid_response):
+    with pytest.raises(TypeError):
+        WellKnownAPIDump(**invalid_response)

--- a/tests/test_undefined_parameters.py
+++ b/tests/test_undefined_parameters.py
@@ -1,0 +1,109 @@
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+import pytest
+import marshmallow
+
+from dataclasses_json.core import Json, UndefinedParameterError, UndefinedParameters
+from dataclasses_json.mm import CatchAll
+from dataclasses_json.api import dataclass_json
+
+
+@dataclass_json(undefined_parameters=UndefinedParameters.CATCH_ALL)
+@dataclass()
+class UnknownAPIDump:
+    endpoint: str
+    data: Dict[str, Any]
+    catch_all: CatchAll
+
+
+@dataclass_json(undefined_parameters=UndefinedParameters.CATCH_ALL)
+@dataclass()
+class UnknownAPIDumpNoCatchAllField:
+    endpoint: str
+    data: Dict[str, Any]
+
+
+@dataclass_json(undefined_parameters=UndefinedParameters.RAISE)
+@dataclass()
+class WellKnownAPIDump:
+    endpoint: str
+    data: Dict[str, Any]
+
+
+@dataclass_json(undefined_parameters=UndefinedParameters.IGNORE)
+@dataclass
+class DontCareAPIDump:
+    endpoint: str
+    data: Dict[str, Any]
+
+
+@pytest.fixture
+def valid_response() -> Dict[Any, Json]:
+    return {"endpoint": "some_api_endpoint", "data": {"foo": 1, "bar": "2"}}
+
+
+@pytest.fixture()
+def invalid_response(valid_response):
+    valid_response["undefined_field_name"] = [1, 2, 3]
+    return valid_response
+
+
+def test_undefined_parameters_catch_all_invalid(invalid_response):
+    dump = UnknownAPIDump.from_dict(invalid_response)
+    assert dump.catch_all == {"undefined_field_name": invalid_response["undefined_field_name"]}
+
+
+def test_undefined_parameters_catch_all_valid(valid_response):
+    dump = UnknownAPIDump.from_dict(valid_response)
+    assert dump.catch_all == {}
+
+
+def test_undefined_parameters_catch_all_no_field(invalid_response):
+    with pytest.raises(UndefinedParameterError):
+        UnknownAPIDumpNoCatchAllField.from_dict(invalid_response)
+
+
+def test_undefined_parameters_raise_invalid(invalid_response):
+    with pytest.raises(UndefinedParameterError):
+        WellKnownAPIDump.from_dict(invalid_response)
+
+
+def test_undefined_parameters_raise_valid(valid_response):
+    assert valid_response == WellKnownAPIDump.from_dict(valid_response).to_dict()
+
+
+def test_undefined_parameters_ignore(valid_response, invalid_response):
+    from_valid = DontCareAPIDump.from_dict(valid_response)
+    from_invalid = DontCareAPIDump.from_dict(invalid_response)
+    assert from_valid == from_invalid
+
+
+def test_undefined_parameters_ignore_nested():
+    @dataclass_json(undefined_parameters=UndefinedParameters.IGNORE)
+    @dataclass(frozen=True)
+    class Minion:
+        name: str
+
+    @dataclass_json
+    @dataclass(frozen=True)
+    class Boss:
+        minions: List[Minion]
+
+    boss_json = """
+    {
+        "minions": [
+            {
+                "name": "evil minion", 
+                "UNKNOWN_PROPERTY" : "value"
+            },
+            {
+                "name": "very evil minion"
+            }
+        ],
+        "UNKNOWN_PROPERTY" : "value"
+    }
+    """.strip()
+    boss = Boss.schema(unknown=marshmallow.INCLUDE).loads(boss_json)
+    assert len(boss.minions) == 2
+    assert boss.minions == [Minion(name="evil minion"), Minion(name="very evil minion")]

--- a/tests/test_undefined_parameters.py
+++ b/tests/test_undefined_parameters.py
@@ -311,9 +311,9 @@ def test_undefined_parameters_doesnt_raise_with_default(valid_response, invalid_
         data: Dict[str, Any]
         catch_all: CatchAll = None
 
-    # from_valid = UnknownAPIDumpDefault.from_dict(valid_response)
+    from_valid = UnknownAPIDumpDefault.from_dict(valid_response)
     from_invalid = UnknownAPIDumpDefault.from_dict(invalid_response)
-    # assert from_valid.catch_all is None
+    assert from_valid.catch_all is None
     assert {"undefined_field_name": [1, 2, 3]} == from_invalid.catch_all
 
 
@@ -339,6 +339,27 @@ def test_undefined_parameters_catch_all_init_valid(valid_response):
 def test_undefined_parameters_catch_all_init_invalid(invalid_response):
     dump = UnknownAPIDump(**invalid_response)
     assert {"undefined_field_name": [1, 2, 3]} == dump.catch_all
+
+
+def test_undefined_parameters_catch_all_init_args():
+    dump = UnknownAPIDump("some-endpoint", {"some-data": "foo"}, "unknown1", "unknown2", undefined="123")
+    assert dump.endpoint == "some-endpoint"
+    assert dump.data == {"some-data": "foo"}
+    assert dump.catch_all == {'_UNKNOWN0': 'unknown1', '_UNKNOWN1': 'unknown2', "undefined": "123"}
+
+
+def test_undefined_parameters_catch_all_init_args_kwargs_mixed():
+    dump = UnknownAPIDump("some-endpoint", {"some-data": "foo"}, "unknown1", "unknown2", catch_all={"bar": "example"},
+                          undefined="123")
+    assert dump.endpoint == "some-endpoint"
+    assert dump.data == {"some-data": "foo"}
+    assert dump.catch_all == {'_UNKNOWN0': 'unknown1', '_UNKNOWN1': 'unknown2', "bar": "example", "undefined": "123"}
+
+
+def test_undefined_parameters_ignore_init_args():
+    dump = DontCareAPIDump("some-endpoint", {"some-data": "foo"}, "unknown1", "unknown2", undefined="123")
+    assert dump.endpoint == "some-endpoint"
+    assert dump.data == {"some-data": "foo"}
 
 
 def test_undefined_parameters_ignore_init_invalid(invalid_response, valid_response):

--- a/tests/test_undefined_parameters.py
+++ b/tests/test_undefined_parameters.py
@@ -282,3 +282,15 @@ def test_undefined_parameters_default_doesnt_do_anything(valid_response):
 
     dump = DefaultAPIDump.from_dict(valid_response)
     assert valid_response == dump.to_dict()
+
+
+def test_it_works_with_default_argument(invalid_response):
+    @dataclass_json(undefined_parameters="include")
+    @dataclass()
+    class UnknownAPIDumpDefault:
+        endpoint: str
+        data: Dict[str, Any]
+        catch_all: CatchAll = None
+
+    dump = UnknownAPIDumpDefault(**invalid_response)
+    assert {"undefined_field_name": [1, 2, 3]} == dump.catch_all

--- a/tests/test_undefined_parameters.py
+++ b/tests/test_undefined_parameters.py
@@ -5,7 +5,7 @@ import pytest
 import marshmallow
 
 from dataclasses_json.core import Json
-from dataclasses_json.api import dataclass_json, LetterCase, UndefinedParameters
+from dataclasses_json.api import dataclass_json, LetterCase, UndefinedParameters, DataClassJsonMixin
 from dataclasses_json import CatchAll
 from dataclasses_json.mm import UndefinedParameterError
 
@@ -320,14 +320,14 @@ def test_undefined_parameters_doesnt_raise_with_default(valid_response, invalid_
 def test_undefined_parameters_doesnt_raise_with_default_factory(valid_response, invalid_response):
     @dataclass_json(undefined_parameters="include")
     @dataclass()
-    class UnknownAPIDumpDefault:
+    class UnknownAPIDumpDefault(DataClassJsonMixin):
         endpoint: str
         data: Dict[str, Any]
-        catch_all: CatchAll = field(default_factory=list)
+        catch_all: CatchAll = field(default_factory=dict)
 
     from_valid = UnknownAPIDumpDefault.from_dict(valid_response)
     from_invalid = UnknownAPIDumpDefault.from_dict(invalid_response)
-    assert from_valid.catch_all == []
+    assert from_valid.catch_all == {}
     assert {"undefined_field_name": [1, 2, 3]} == from_invalid.catch_all
 
 
@@ -383,3 +383,15 @@ def test_undefined_parameters_catch_all_default_no_undefined(valid_response):
 
     dump = UnknownAPIDumpDefault.from_dict(valid_response)
     assert dump.to_dict() == valid_response
+
+
+def test_undefined_parameters_catch_all_default_factory_init_converts_factory(valid_response):
+    @dataclass_json(undefined_parameters="include")
+    @dataclass()
+    class UnknownAPIDumpDefault:
+        endpoint: str
+        data: Dict[str, Any]
+        catch_all: CatchAll = field(default_factory=dict)
+
+    dump = UnknownAPIDumpDefault(**valid_response)
+    assert dump.catch_all == {}

--- a/tests/test_undefined_parameters.py
+++ b/tests/test_undefined_parameters.py
@@ -5,12 +5,12 @@ import pytest
 import marshmallow
 
 from dataclasses_json.core import Json
-from dataclasses_json.api import dataclass_json, LetterCase, UndefinedParameters, DataClassJsonMixin
+from dataclasses_json.api import dataclass_json, LetterCase, Undefined, DataClassJsonMixin
 from dataclasses_json import CatchAll
 from dataclasses_json.mm import UndefinedParameterError
 
 
-@dataclass_json(undefined_parameters=UndefinedParameters.INCLUDE)
+@dataclass_json(undefined=Undefined.INCLUDE)
 @dataclass()
 class UnknownAPIDump:
     endpoint: str
@@ -18,21 +18,21 @@ class UnknownAPIDump:
     catch_all: CatchAll
 
 
-@dataclass_json(undefined_parameters=UndefinedParameters.INCLUDE)
+@dataclass_json(undefined=Undefined.INCLUDE)
 @dataclass()
 class UnknownAPIDumpNoCatchAllField:
     endpoint: str
     data: Dict[str, Any]
 
 
-@dataclass_json(undefined_parameters=UndefinedParameters.RAISE)
+@dataclass_json(undefined=Undefined.RAISE)
 @dataclass()
 class WellKnownAPIDump:
     endpoint: str
     data: Dict[str, Any]
 
 
-@dataclass_json(undefined_parameters=UndefinedParameters.EXCLUDE)
+@dataclass_json(undefined=Undefined.EXCLUDE)
 @dataclass
 class DontCareAPIDump:
     endpoint: str
@@ -94,7 +94,7 @@ def test_undefined_parameters_catch_all_no_field(invalid_response):
 
 
 def test_undefined_parameters_catch_all_multiple_fields(invalid_response):
-    @dataclass_json(undefined_parameters=UndefinedParameters.INCLUDE)
+    @dataclass_json(undefined=Undefined.INCLUDE)
     @dataclass()
     class UnknownAPIDumpMultipleCatchAll:
         endpoint: str
@@ -107,7 +107,7 @@ def test_undefined_parameters_catch_all_multiple_fields(invalid_response):
 
 
 def test_undefined_parameters_catch_all_works_with_letter_case(invalid_response_camel_case):
-    @dataclass_json(undefined_parameters=UndefinedParameters.INCLUDE, letter_case=LetterCase.CAMEL)
+    @dataclass_json(undefined=Undefined.INCLUDE, letter_case=LetterCase.CAMEL)
     @dataclass()
     class UnknownAPIDumpCamelCase:
         endpoint: str
@@ -153,12 +153,12 @@ def test_undefined_parameters_ignore_to_dict(invalid_response, valid_response):
 
 
 def test_undefined_parameters_ignore_nested_schema(boss_json):
-    @dataclass_json(undefined_parameters=UndefinedParameters.EXCLUDE)
+    @dataclass_json(undefined=Undefined.EXCLUDE)
     @dataclass(frozen=True)
     class Minion:
         name: str
 
-    @dataclass_json(undefined_parameters=UndefinedParameters.EXCLUDE)
+    @dataclass_json(undefined=Undefined.EXCLUDE)
     @dataclass(frozen=True)
     class Boss:
         minions: List[Minion]
@@ -169,12 +169,12 @@ def test_undefined_parameters_ignore_nested_schema(boss_json):
 
 
 def test_undefined_parameters_raise_nested_schema(boss_json):
-    @dataclass_json(undefined_parameters=UndefinedParameters.RAISE)
+    @dataclass_json(undefined=Undefined.RAISE)
     @dataclass(frozen=True)
     class Minion:
         name: str
 
-    @dataclass_json(undefined_parameters=UndefinedParameters.EXCLUDE)
+    @dataclass_json(undefined=Undefined.EXCLUDE)
     @dataclass(frozen=True)
     class Boss:
         minions: List[Minion]
@@ -184,13 +184,13 @@ def test_undefined_parameters_raise_nested_schema(boss_json):
 
 
 def test_undefined_parameters_catch_all_nested_schema(boss_json):
-    @dataclass_json(undefined_parameters=UndefinedParameters.INCLUDE)
+    @dataclass_json(undefined=Undefined.INCLUDE)
     @dataclass(frozen=True)
     class Minion:
         name: str
         catch_all: CatchAll
 
-    @dataclass_json(undefined_parameters=UndefinedParameters.INCLUDE)
+    @dataclass_json(undefined=Undefined.INCLUDE)
     @dataclass(frozen=True)
     class Boss:
         minions: List[Minion]
@@ -205,13 +205,13 @@ def test_undefined_parameters_catch_all_nested_schema(boss_json):
 def test_undefined_parameters_catch_all_schema_dump(boss_json):
     import json
 
-    @dataclass_json(undefined_parameters=UndefinedParameters.INCLUDE)
+    @dataclass_json(undefined=Undefined.INCLUDE)
     @dataclass(frozen=True)
     class Minion:
         name: str
         catch_all: CatchAll
 
-    @dataclass_json(undefined_parameters=UndefinedParameters.INCLUDE)
+    @dataclass_json(undefined=Undefined.INCLUDE)
     @dataclass(frozen=True)
     class Boss:
         minions: List[Minion]
@@ -223,13 +223,13 @@ def test_undefined_parameters_catch_all_schema_dump(boss_json):
 
 
 def test_undefined_parameters_catch_all_schema_roundtrip(boss_json):
-    @dataclass_json(undefined_parameters=UndefinedParameters.INCLUDE)
+    @dataclass_json(undefined=Undefined.INCLUDE)
     @dataclass(frozen=True)
     class Minion:
         name: str
         catch_all: CatchAll
 
-    @dataclass_json(undefined_parameters=UndefinedParameters.INCLUDE)
+    @dataclass_json(undefined=Undefined.INCLUDE)
     @dataclass(frozen=True)
     class Boss:
         minions: List[Minion]
@@ -242,12 +242,12 @@ def test_undefined_parameters_catch_all_schema_roundtrip(boss_json):
 
 
 def test_undefined_parameters_catch_all_ignore_mix_nested_schema(boss_json):
-    @dataclass_json(undefined_parameters=UndefinedParameters.EXCLUDE)
+    @dataclass_json(undefined=Undefined.EXCLUDE)
     @dataclass(frozen=True)
     class Minion:
         name: str
 
-    @dataclass_json(undefined_parameters=UndefinedParameters.INCLUDE)
+    @dataclass_json(undefined=Undefined.INCLUDE)
     @dataclass(frozen=True)
     class Boss:
         minions: List[Minion]
@@ -260,7 +260,7 @@ def test_undefined_parameters_catch_all_ignore_mix_nested_schema(boss_json):
 
 
 def test_it_works_from_string(invalid_response):
-    @dataclass_json(undefined_parameters="include")
+    @dataclass_json(undefined="include")
     @dataclass()
     class UnknownAPIDumpFromString:
         endpoint: str
@@ -273,25 +273,14 @@ def test_it_works_from_string(invalid_response):
 
 def test_string_only_accepts_valid_actions():
     with pytest.raises(UndefinedParameterError):
-        @dataclass_json(undefined_parameters="not sure what this is supposed to do")
+        @dataclass_json(undefined="not sure what this is supposed to do")
         @dataclass()
         class WontWork:
             endpoint: str
 
 
-def test_undefined_parameters_default_doesnt_do_anything(valid_response):
-    @dataclass_json(undefined_parameters=UndefinedParameters.DEFAULT)
-    @dataclass()
-    class DefaultAPIDump:
-        endpoint: str
-        data: Dict[str, Any]
-
-    dump = DefaultAPIDump.from_dict(valid_response)
-    assert valid_response == dump.to_dict()
-
-
 def test_undefined_parameters_raises_with_default_argument_and_supplied_catch_all_name(invalid_response):
-    @dataclass_json(undefined_parameters="include")
+    @dataclass_json(undefined="include")
     @dataclass()
     class UnknownAPIDumpDefault:
         endpoint: str
@@ -304,7 +293,7 @@ def test_undefined_parameters_raises_with_default_argument_and_supplied_catch_al
 
 
 def test_undefined_parameters_doesnt_raise_with_default(valid_response, invalid_response):
-    @dataclass_json(undefined_parameters="include")
+    @dataclass_json(undefined="include")
     @dataclass()
     class UnknownAPIDumpDefault:
         endpoint: str
@@ -318,7 +307,7 @@ def test_undefined_parameters_doesnt_raise_with_default(valid_response, invalid_
 
 
 def test_undefined_parameters_doesnt_raise_with_default_factory(valid_response, invalid_response):
-    @dataclass_json(undefined_parameters="include")
+    @dataclass_json(undefined="include")
     @dataclass()
     class UnknownAPIDumpDefault(DataClassJsonMixin):
         endpoint: str
@@ -374,7 +363,7 @@ def test_undefined_parameters_raise_init(invalid_response):
 
 
 def test_undefined_parameters_catch_all_default_no_undefined(valid_response):
-    @dataclass_json(undefined_parameters="include")
+    @dataclass_json(undefined="include")
     @dataclass()
     class UnknownAPIDumpDefault:
         endpoint: str
@@ -386,7 +375,7 @@ def test_undefined_parameters_catch_all_default_no_undefined(valid_response):
 
 
 def test_undefined_parameters_catch_all_default_factory_init_converts_factory(valid_response):
-    @dataclass_json(undefined_parameters="include")
+    @dataclass_json(undefined="include")
     @dataclass()
     class UnknownAPIDumpDefault:
         endpoint: str

--- a/tests/test_undefined_parameters.py
+++ b/tests/test_undefined_parameters.py
@@ -328,3 +328,8 @@ def test_undefined_parameters_doesnt_raise_with_default_factory(valid_response, 
 def test_undefined_parameters_catch_all_init_valid(valid_response):
     dump = UnknownAPIDump(**valid_response)
     assert dump.catch_all == {}
+
+
+def test_undefined_parameters_catch_all_init_invalid(invalid_response):
+    dump = UnknownAPIDump(**invalid_response)
+    assert {"undefined_field_name": [1, 2, 3]} == dump.catch_all

--- a/tests/test_undefined_parameters.py
+++ b/tests/test_undefined_parameters.py
@@ -371,3 +371,15 @@ def test_undefined_parameters_ignore_init_invalid(invalid_response, valid_respon
 def test_undefined_parameters_raise_init(invalid_response):
     with pytest.raises(TypeError):
         WellKnownAPIDump(**invalid_response)
+
+
+def test_undefined_parameters_catch_all_default_no_undefined(valid_response):
+    @dataclass_json(undefined_parameters="include")
+    @dataclass()
+    class UnknownAPIDumpDefault:
+        endpoint: str
+        data: Dict[str, Any]
+        catch_all: CatchAll = None
+
+    dump = UnknownAPIDumpDefault.from_dict(valid_response)
+    assert dump.to_dict() == valid_response

--- a/tests/test_undefined_parameters.py
+++ b/tests/test_undefined_parameters.py
@@ -4,12 +4,13 @@ from typing import Any, Dict, List
 import pytest
 import marshmallow
 
-from dataclasses_json.core import Json, UndefinedParameterError, UndefinedParameters
-from dataclasses_json.mm import CatchAll
-from dataclasses_json.api import dataclass_json, LetterCase
+from dataclasses_json.core import Json
+from dataclasses_json.api import dataclass_json, LetterCase, UndefinedParameters
+from dataclasses_json import CatchAll
+from dataclasses_json.mm import UndefinedParameterError
 
 
-@dataclass_json(undefined_parameters=UndefinedParameters.CATCH_ALL)
+@dataclass_json(undefined_parameters=UndefinedParameters.INCLUDE)
 @dataclass()
 class UnknownAPIDump:
     endpoint: str
@@ -17,7 +18,7 @@ class UnknownAPIDump:
     catch_all: CatchAll
 
 
-@dataclass_json(undefined_parameters=UndefinedParameters.CATCH_ALL)
+@dataclass_json(undefined_parameters=UndefinedParameters.INCLUDE)
 @dataclass()
 class UnknownAPIDumpNoCatchAllField:
     endpoint: str
@@ -31,7 +32,7 @@ class WellKnownAPIDump:
     data: Dict[str, Any]
 
 
-@dataclass_json(undefined_parameters=UndefinedParameters.IGNORE)
+@dataclass_json(undefined_parameters=UndefinedParameters.EXCLUDE)
 @dataclass
 class DontCareAPIDump:
     endpoint: str
@@ -45,14 +46,35 @@ def valid_response() -> Dict[Any, Json]:
 
 @pytest.fixture()
 def invalid_response(valid_response):
-    valid_response["undefined_field_name"] = [1, 2, 3]
-    return valid_response
+    invalid_response = valid_response.copy()
+    invalid_response["undefined_field_name"] = [1, 2, 3]
+    return invalid_response
 
 
 @pytest.fixture()
 def invalid_response_camel_case(valid_response):
-    valid_response["undefinedFieldName"] = [1, 2, 3]
-    return valid_response
+    invalid_response = valid_response.copy()
+    invalid_response["undefinedFieldName"] = [1, 2, 3]
+    return invalid_response
+
+
+@pytest.fixture()
+def boss_json():
+    boss_json = """
+    {
+        "minions": [
+            {
+                "name": "evil minion", 
+                "UNKNOWN_PROPERTY" : "value"
+            },
+            {
+                "name": "very evil minion"
+            }
+        ],
+        "UNKNOWN_PROPERTY" : "value"
+    }
+    """.strip()
+    return boss_json
 
 
 def test_undefined_parameters_catch_all_invalid_back(invalid_response):
@@ -72,7 +94,7 @@ def test_undefined_parameters_catch_all_no_field(invalid_response):
 
 
 def test_undefined_parameters_catch_all_multiple_fields(invalid_response):
-    @dataclass_json(undefined_parameters=UndefinedParameters.CATCH_ALL)
+    @dataclass_json(undefined_parameters=UndefinedParameters.INCLUDE)
     @dataclass()
     class UnknownAPIDumpMultipleCatchAll:
         endpoint: str
@@ -85,7 +107,7 @@ def test_undefined_parameters_catch_all_multiple_fields(invalid_response):
 
 
 def test_undefined_parameters_catch_all_works_with_letter_case(invalid_response_camel_case):
-    @dataclass_json(undefined_parameters=UndefinedParameters.CATCH_ALL, letter_case=LetterCase.CAMEL)
+    @dataclass_json(undefined_parameters=UndefinedParameters.INCLUDE, letter_case=LetterCase.CAMEL)
     @dataclass()
     class UnknownAPIDumpCamelCase:
         endpoint: str
@@ -118,31 +140,134 @@ def test_undefined_parameters_ignore(valid_response, invalid_response):
     assert from_valid == from_invalid
 
 
-def test_undefined_parameters_ignore_nested():
-    @dataclass_json(undefined_parameters=UndefinedParameters.IGNORE)
+def test_undefined_parameters_ignore_to_dict(invalid_response, valid_response):
+    dump = DontCareAPIDump.from_dict(invalid_response)
+    dump_dict = dump.to_dict()
+    assert valid_response == dump_dict
+
+
+def test_undefined_parameters_ignore_nested_schema(boss_json):
+    @dataclass_json(undefined_parameters=UndefinedParameters.EXCLUDE)
     @dataclass(frozen=True)
     class Minion:
         name: str
 
-    @dataclass_json
+    @dataclass_json(undefined_parameters=UndefinedParameters.EXCLUDE)
     @dataclass(frozen=True)
     class Boss:
         minions: List[Minion]
 
-    boss_json = """
-    {
-        "minions": [
-            {
-                "name": "evil minion", 
-                "UNKNOWN_PROPERTY" : "value"
-            },
-            {
-                "name": "very evil minion"
-            }
-        ],
-        "UNKNOWN_PROPERTY" : "value"
-    }
-    """.strip()
-    boss = Boss.schema(unknown=marshmallow.INCLUDE).loads(boss_json)
+    boss = Boss.schema().loads(boss_json)
     assert len(boss.minions) == 2
     assert boss.minions == [Minion(name="evil minion"), Minion(name="very evil minion")]
+
+
+def test_undefined_parameters_raise_nested_schema(boss_json):
+    @dataclass_json(undefined_parameters=UndefinedParameters.RAISE)
+    @dataclass(frozen=True)
+    class Minion:
+        name: str
+
+    @dataclass_json(undefined_parameters=UndefinedParameters.EXCLUDE)
+    @dataclass(frozen=True)
+    class Boss:
+        minions: List[Minion]
+
+    with pytest.raises(marshmallow.exceptions.ValidationError):
+        Boss.schema().loads(boss_json)
+
+
+def test_undefined_parameters_catch_all_nested_schema(boss_json):
+    @dataclass_json(undefined_parameters=UndefinedParameters.INCLUDE)
+    @dataclass(frozen=True)
+    class Minion:
+        name: str
+        catch_all: CatchAll
+
+    @dataclass_json(undefined_parameters=UndefinedParameters.INCLUDE)
+    @dataclass(frozen=True)
+    class Boss:
+        minions: List[Minion]
+        catch_all: CatchAll
+
+    boss = Boss.schema().loads(boss_json)
+    assert {"UNKNOWN_PROPERTY": "value"} == boss.catch_all
+    assert {"UNKNOWN_PROPERTY": "value"} == boss.minions[0].catch_all
+    assert {} == boss.minions[1].catch_all
+
+
+def test_undefined_parameters_catch_all_schema_dump(boss_json):
+    import json
+
+    @dataclass_json(undefined_parameters=UndefinedParameters.INCLUDE)
+    @dataclass(frozen=True)
+    class Minion:
+        name: str
+        catch_all: CatchAll
+
+    @dataclass_json(undefined_parameters=UndefinedParameters.INCLUDE)
+    @dataclass(frozen=True)
+    class Boss:
+        minions: List[Minion]
+        catch_all: CatchAll
+
+    boss = Boss.schema().loads(boss_json)
+    assert json.loads(boss_json) == Boss.schema().dump(boss)
+    assert "".join(boss_json.replace('\n', '').split()) == "".join(Boss.schema().dumps(boss).replace('\n', '').split())
+
+
+def test_undefined_parameters_catch_all_schema_roundtrip(boss_json):
+    @dataclass_json(undefined_parameters=UndefinedParameters.INCLUDE)
+    @dataclass(frozen=True)
+    class Minion:
+        name: str
+        catch_all: CatchAll
+
+    @dataclass_json(undefined_parameters=UndefinedParameters.INCLUDE)
+    @dataclass(frozen=True)
+    class Boss:
+        minions: List[Minion]
+        catch_all: CatchAll
+
+    boss1 = Boss.schema().loads(boss_json)
+    dumped_s = Boss.schema().dumps(boss1)
+    boss2 = Boss.schema().loads(dumped_s)
+    assert boss1 == boss2
+
+
+def test_undefined_parameters_catch_all_ignore_mix_nested_schema(boss_json):
+    @dataclass_json(undefined_parameters=UndefinedParameters.EXCLUDE)
+    @dataclass(frozen=True)
+    class Minion:
+        name: str
+
+    @dataclass_json(undefined_parameters=UndefinedParameters.INCLUDE)
+    @dataclass(frozen=True)
+    class Boss:
+        minions: List[Minion]
+        catch_all: CatchAll
+
+    boss = Boss.schema().loads(boss_json)
+    assert Minion(name="evil minion") == boss.minions[0]
+    assert Minion(name="very evil minion") == boss.minions[1]
+    assert {"UNKNOWN_PROPERTY": "value"} == boss.catch_all
+
+
+def test_it_works_from_string(invalid_response):
+    @dataclass_json(undefined_parameters="include")
+    @dataclass()
+    class UnknownAPIDumpFromString:
+        endpoint: str
+        data: Dict[str, Any]
+        catch_all: CatchAll
+
+    dump = UnknownAPIDumpFromString.from_dict(invalid_response)
+    assert {"undefined_field_name": [1, 2, 3]} == dump.catch_all
+
+
+def test_string_only_accepts_valid_actions():
+    with pytest.raises(UndefinedParameterError):
+        @dataclass_json(undefined_parameters="not sure what this is supposed to do")
+        @dataclass()
+        class WontWork:
+            endpoint: str

--- a/tests/test_undefined_parameters.py
+++ b/tests/test_undefined_parameters.py
@@ -333,3 +333,9 @@ def test_undefined_parameters_catch_all_init_valid(valid_response):
 def test_undefined_parameters_catch_all_init_invalid(invalid_response):
     dump = UnknownAPIDump(**invalid_response)
     assert {"undefined_field_name": [1, 2, 3]} == dump.catch_all
+
+
+def test_undefined_parameters_ignore_init_invalid(invalid_response, valid_response):
+    dump_invalid = DontCareAPIDump(**invalid_response)
+    dump_valid = DontCareAPIDump(**valid_response)
+    assert dump_valid == dump_invalid

--- a/tests/test_undefined_parameters.py
+++ b/tests/test_undefined_parameters.py
@@ -271,3 +271,14 @@ def test_string_only_accepts_valid_actions():
         @dataclass()
         class WontWork:
             endpoint: str
+
+
+def test_undefined_parameters_default_doesnt_do_anything(valid_response):
+    @dataclass_json(undefined_parameters=UndefinedParameters.DEFAULT)
+    @dataclass()
+    class DefaultAPIDump:
+        endpoint: str
+        data: Dict[str, Any]
+
+    dump = DefaultAPIDump.from_dict(valid_response)
+    assert valid_response == dump.to_dict()


### PR DESCRIPTION
I implemented customizable behaviors when a dataclass_json object encounters keyword parameters during initialization that are not defined as fields.
The following snipped has also been added to the README, and there are several testcases for everything.
It works with `schema()` as well as `to_dict(), from_dict()` and `__init__`.
Closes #94 


### Handle unknown input data?

By default, it is up to implementation what happens when a `json_dataclass` receives input parameters that are not defined.
(the `from_dict` method ignores them, when loading using `schema()` a ValidationError is raised.)
There are three ways to customize this behavior.

Assume you want to instantiate a dataclass with for the following dictionary:
```python
dump_dict = {"endpoint": "some_api_endpoint", "data": {"foo": 1, "bar": "2"}, "undefined_field_name": [1, 2, 3]}
```

1. You can enforce to always raise an error by setting the undefined_parameters keyword to `UndefinedParameters.RAISE`
 (`'RAISE'` as a case-insensitive string works as well). Of course it works normally if you don't pass any undefined parameters.
    
    ```python
    from dataclasses_json import UndefinedParameters
    
    @dataclass_json(undefined_parameters=UndefinedParameters.RAISE)
    @dataclass()
    class ExactAPIDump:
        endpoint: str
        data: Dict[str, Any]
    
    dump = ExactAPIDump.from_dict(dump_dict)  # raises UndefinedParameterError
    ```

2. You can simply ignore any undefined parameters by setting the undefined_parameters keyword to `UndefinedParameters.EXCLUDE`
 (`'EXCLUDE'` as a case-insensitive string works as well). Note that you will not be able to retrieve them using `to_dict`:
    
    ```python
    from dataclasses_json import UndefinedParameters
    
    @dataclass_json(undefined_parameters=UndefinedParameters.EXCLUDE)
    @dataclass()
    class DontCareAPIDump:
        endpoint: str
        data: Dict[str, Any]
    
    dump = DontCareAPIDump.from_dict(dump_dict)  # DontCareAPIDump(endpoint='some_api_endpoint', data={'foo': 1, 'bar': '2'})
    dump.to_dict()  # {"endpoint": "some_api_endpoint", "data": {"foo": 1, "bar": "2"}}
    ```

3. You can save them in a catch-all field and do whatever needs to be done later. Simply set the undefined_parameters
keyword to `UndefinedParameters.INCLUDE` (`'INCLUDE'` as a case-insensitive string works as well) and define a field
of type `CatchAll` where all unknown values will end up.
 This simply represents a dictionary that can hold anything. 
 If there are no undefined parameters, this will be an empty dictionary.
    
    ```python
    from dataclasses_json import UndefinedParameters, CatchAll
    
    @dataclass_json(undefined_parameters=UndefinedParameters.INCLUDE)
    @dataclass()
    class UnknownAPIDump:
        endpoint: str
        data: Dict[str, Any]
        unknown_things: CatchAll
    
    dump = UnknownAPIDump.from_dict(dump_dict)  # UnknownAPIDump(endpoint='some_api_endpoint', data={'foo': 1, 'bar': '2'}, unknown_things={'undefined_field_name': [1, 2, 3]})
    dump.to_dict()  # {'endpoint': 'some_api_endpoint', 'data': {'foo': 1, 'bar': '2'}, 'undefined_field_name': [1, 2, 3]}
    ```

    - When using `UndefinedParameters.INCLUDE`, an `UndefinedParameterError` will be raised if you don't specify
    exactly one field of type `CatchAll`.
    - Note that `LetterCase` does not affect values written into the `CatchAll` field, they will be as they are given.
    - When specifying a default (or a default factory) for the the `CatchAll`-field, e.g. `unknown_things: CatchAll = None`, the default value will be used instead of an empty dict if there are no undefined parameters.
    - Calling __init__ with non-keyword arguments resolves the arguments to the defined fields and writes everything else into the catch-all field.

4. All 3 options work as well using `schema().loads` and `schema().dumps`, as long as you don't overwrite it by specifying `schema(unknown=<a marshmallow value>)`.
marshmallow uses the same 3 keywords ['include', 'exclude', 'raise'](https://marshmallow.readthedocs.io/en/stable/quickstart.html#handling-unknown-fields).

5. All 3 operations work as well using `__init__`, e.g. `UnknownAPIDump(**dump_dict)` will **not** raise a `TypeError`, but write all unknown values to the field tagged as `CatchAll`.
   Classes tagged with `EXCLUDE` will also simply ignore unknown parameters. Note that classes tagged as `RAISE` still raise a `TypeError`, and **not** a `UndefinedParameterError` if supplied with unknown keywords.

