### PR TITLE
Support usage of a custom encoder on nested dataclasses

### DIFF
--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -288,7 +288,10 @@ def _asdict(obj, encode_json=False):
     if _is_dataclass_instance(obj):
         result = []
         for field in fields(obj):
-            value = _asdict(getattr(obj, field.name), encode_json=encode_json)
+            _field = getattr(obj, field.name)
+            value = _field.to_dict(encode_json=encode_json) \
+                if hasattr(_field, 'to_dict') \
+                else _asdict(_field, encode_json=encode_json)
             result.append((field.name, value))
 
         result = _handle_undefined_parameters_safe(cls=obj, kvs=dict(result),

--- a/tests/entities.py
+++ b/tests/entities.py
@@ -17,6 +17,8 @@ from marshmallow import fields
 
 import dataclasses_json
 from datetime import datetime
+
+from core import Json
 from dataclasses_json import (DataClassJsonMixin, LetterCase, dataclass_json)
 
 A = TypeVar('A')
@@ -246,3 +248,24 @@ class DataClassWithOptionalDecimal:
 @dataclass
 class DataClassWithOptionalUuid:
     a: Optional[UUID]
+
+
+class StripNoneDataClassJsonMixin(DataClassJsonMixin):
+    """
+    Strip fields in serialization if their value is None
+    """
+
+    def to_dict(self, encode_json=False) -> Dict[str, Json]:
+        return {k: v for k, v in super().to_dict(encode_json).items() if v is not None}
+
+
+@dataclass
+class DataClassWithCustomEncoder(StripNoneDataClassJsonMixin):
+    a: int
+    b: Optional[bool] = None
+
+
+@dataclass_json
+@dataclass
+class DataClassWithNestedCustomEncoder:
+    a: DataClassWithCustomEncoder

--- a/tests/test_nested.py
+++ b/tests/test_nested.py
@@ -1,7 +1,9 @@
 from tests.entities import (DataClassWithDataClass,
                             DataClassWithList,
                             DataClassX,
-                            DataClassXs)
+                            DataClassXs,
+                            DataClassWithNestedCustomEncoder,
+                            DataClassWithCustomEncoder)
 
 
 class TestEncoder:
@@ -13,6 +15,9 @@ class TestEncoder:
         assert (DataClassXs([DataClassX(0), DataClassX(1)]).to_json() ==
                 '{"xs": [{"x": 0}, {"x": 1}]}')
 
+    def test_nested_custom_encoded_dataclass(self):
+        assert (DataClassWithNestedCustomEncoder(DataClassWithCustomEncoder(1, None))).to_json() == '{"a": {"a": 1}}'
+
 
 class TestDecoder:
     def test_nested_dataclass(self):
@@ -23,3 +28,7 @@ class TestDecoder:
     def test_nested_list_of_dataclasses(self):
         assert (DataClassXs.from_json('{"xs": [{"x": 0}, {"x": 1}]}') ==
                 DataClassXs([DataClassX(0), DataClassX(1)]))
+
+    def test_nested_custom_encoded_dataclass(self):
+        assert (DataClassWithNestedCustomEncoder.from_json('{"a": {"a": 1}}') ==
+                DataClassWithNestedCustomEncoder(DataClassWithCustomEncoder(1, None)))


### PR DESCRIPTION
Currently, if we use a custom encoder on a nested dataclass, it is not called during serialization.

This pull request fixes it, with associated test cases.

As my use case (and thus the unit test 😄) was to strip `None` values at serialization, I was wondering if this was a common enough use case to add a boolean flag in the dataclass_json configuration to avoid writing a custom Encoder:

```python
def dataclass_json(_cls=None, *, letter_case=None,
                   undefined: Optional[Union[str, Undefined]] = None,
                   skip_none: Optional[bool] = None):
```

If that's the case, I shall add this case to the `config` and see from there how to use the `cls.dataclass_json_config` at serialization time