### PR TITLE
Fix nested optional type when loading from schema

### DIFF
--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -235,7 +235,10 @@ def _decode_generic(type_, value, infer_missing):
         except TypeError:
             res = type_(xs)
     else:  # Optional or Union
-        if _is_optional(type_) and len(type_.__args__) == 2:  # Optional
+        if not hasattr(type_, "__args__"):
+            # Any, just accept
+            res = value
+        elif _is_optional(type_) and len(type_.__args__) == 2:  # Optional
             type_arg = type_.__args__[0]
             if is_dataclass(type_arg) or is_dataclass(value):
                 res = _decode_dataclass(type_arg, value, infer_missing)

--- a/dataclasses_json/mm.py
+++ b/dataclasses_json/mm.py
@@ -119,6 +119,7 @@ TYPES = {
     typing.Dict: fields.Dict,
     typing.Tuple: fields.Tuple,
     typing.Callable: fields.Function,
+    typing.Any: fields.Raw,
     dict: fields.Dict,
     list: fields.List,
     str: fields.Str,
@@ -248,6 +249,9 @@ def build_type(type_, options, mixin, field, cls):
         origin = getattr(type_, '__origin__', type_)
         args = [inner(a, {}) for a in getattr(type_, '__args__', []) if
                 a is not type(None)]
+
+        if _is_optional(type_):
+            options["allow_none"] = True
 
         if origin in TYPES:
             return TYPES[origin](*args, **options)

--- a/dataclasses_json/utils.py
+++ b/dataclasses_json/utils.py
@@ -1,7 +1,7 @@
 import inspect
 import sys
 from datetime import datetime, timezone
-from typing import Collection, Mapping, Optional, TypeVar
+from typing import Collection, Mapping, Optional, TypeVar, Any
 
 
 def _get_type_cons(type_):
@@ -88,7 +88,9 @@ def _is_new_type(type_):
 
 
 def _is_optional(type_):
-    return _issubclass_safe(type_, Optional) or _hasargs(type_, type(None))
+    return (_issubclass_safe(type_, Optional) or
+            _hasargs(type_, type(None)) or
+            type_ is Any)
 
 
 def _is_mapping(type_):

--- a/tests/entities.py
+++ b/tests/entities.py
@@ -10,7 +10,8 @@ from typing import (Collection,
                     Set,
                     Tuple,
                     TypeVar,
-                    Union)
+                    Union,
+                    Any)
 from uuid import UUID
 
 from marshmallow import fields
@@ -246,3 +247,21 @@ class DataClassWithOptionalDecimal:
 @dataclass
 class DataClassWithOptionalUuid:
     a: Optional[UUID]
+
+
+@dataclass_json
+@dataclass
+class DataClassWithNestedAny:
+    a: Dict[str, Any]
+
+
+@dataclass_json
+@dataclass
+class DataClassWithNestedOptionalAny:
+    a: Dict[str, Optional[Any]]
+
+
+@dataclass_json
+@dataclass
+class DataClassWithNestedOptional:
+    a: Dict[str, Optional[int]]

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,9 +1,10 @@
-from .entities import DataClassDefaultListStr, DataClassDefaultOptionalList, DataClassList, DataClassOptional
+from .entities import (DataClassDefaultListStr, DataClassDefaultOptionalList, DataClassList, DataClassOptional,
+                       DataClassWithNestedOptional, DataClassWithNestedOptionalAny, DataClassWithNestedAny)
 from .test_letter_case import CamelCasePerson, KebabCasePerson, SnakeCasePerson, FieldNamePerson
-
 
 test_do_list = """[{}, {"children": [{"name": "a"}, {"name": "b"}]}]"""
 test_list = '[{"children": [{"name": "a"}, {"name": "b"}]}]'
+nested_optional_data = '{"a": {"test": null}}'
 
 
 class TestSchema:
@@ -27,3 +28,15 @@ class TestSchema:
         for cls in (CamelCasePerson, KebabCasePerson, SnakeCasePerson, FieldNamePerson):
             p = cls('Alice')
             assert p.to_dict() == cls.schema().dump(p)
+
+    def test_nested_optional(self):
+        DataClassWithNestedOptional.schema().loads(nested_optional_data)
+        assert True
+
+    def test_nested_optional_any(self):
+        DataClassWithNestedOptionalAny.schema().loads(nested_optional_data)
+        assert True
+
+    def test_nested_any_accepts_optional(self):
+        DataClassWithNestedAny.schema().loads(nested_optional_data)
+        assert True


### PR DESCRIPTION
Direct response to #166.

This MR fixes 2.5 issues:

1) - A field that was typed as `Any` did not accept `None` values, it does now.
    - A field that was typed as `Any` raised a warning that `Any` is an unknown type. `Any` is now mapped to `fields.Raw` and no longer raises the warning.
2) Nested `Optional` values were not passed on correctly to the schema, resulting in a `ValidationError` when passing `None`, even if the type allowed it (e.g. `Dict[str, Optional[int]]` did not allow optional values). It works now.
