### PR TITLE
add caching, add tests

### DIFF
--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -23,7 +23,7 @@ from dataclasses_json.utils import (_get_type_cons,
                                     _issubclass_safe)
 
 Json = Union[dict, list, str, int, float, bool, None]
-_MAX_CACHE_SIZE = 1
+_MAX_CACHE_SIZE = 128
 _get_type_hints_cache = LRUCache(maxsize=_MAX_CACHE_SIZE)
 _is_supported_generic_cache = LRUCache(maxsize=_MAX_CACHE_SIZE)
 _user_overrides_cache = LRUCache(maxsize=_MAX_CACHE_SIZE)

--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -12,6 +12,8 @@ from enum import Enum
 from typing import Any, Collection, Dict, Mapping, Union, get_type_hints
 from uuid import UUID
 
+from cachetools import cached
+from cachetools.lru import LRUCache
 from typing_inspect import is_union_type  # type: ignore
 
 from dataclasses_json.utils import (_get_type_cons,
@@ -21,6 +23,10 @@ from dataclasses_json.utils import (_get_type_cons,
                                     _issubclass_safe)
 
 Json = Union[dict, list, str, int, float, bool, None]
+_MAX_CACHE_SIZE = 1
+_get_type_hints_cache = LRUCache(maxsize=_MAX_CACHE_SIZE)
+_is_supported_generic_cache = LRUCache(maxsize=_MAX_CACHE_SIZE)
+_user_overrides_cache = LRUCache(maxsize=_MAX_CACHE_SIZE)
 
 
 class _ExtendedEncoder(json.JSONEncoder):
@@ -44,9 +50,12 @@ class _ExtendedEncoder(json.JSONEncoder):
         return result
 
 
-def _user_overrides(cls):
-    confs = ['encoder', 'decoder', 'mm_field', 'letter_case']
-    FieldOverride = namedtuple('FieldOverride', confs)
+confs = ['encoder', 'decoder', 'mm_field', 'letter_case']
+FieldOverride = namedtuple('FieldOverride', confs)
+
+
+@cached(cache=_user_overrides_cache, key=id)
+def _user_overrides(cls) -> Dict[str, FieldOverride]:
 
     overrides = {}
     # overrides at the class-level
@@ -69,7 +78,7 @@ def _encode_json_type(value, default=_ExtendedEncoder().default):
     return default(value)
 
 
-def _encode_overrides(kvs, overrides, encode_json=False):
+def _encode_overrides(kvs: Dict[str, Any], overrides, encode_json=False):
     override_kvs = {}
     for k, v in kvs.items():
         if k in overrides:
@@ -98,6 +107,11 @@ def _decode_letter_case_overrides(field_names, overrides):
     return names
 
 
+@cached(cache=_get_type_hints_cache, key=id)
+def _get_type_hints_cached(cls):
+    return get_type_hints(cls)
+
+
 def _decode_dataclass(cls, kvs, infer_missing):
     if isinstance(kvs, cls):
         return kvs
@@ -120,7 +134,7 @@ def _decode_dataclass(cls, kvs, infer_missing):
     kvs = _handle_undefined_parameters_safe(cls, kvs, usage="from")
 
     init_kwargs = {}
-    types = get_type_hints(cls)
+    types = _get_type_hints_cached(cls)
     for field in fields(cls):
         # The field should be skipped from being added
         # to init_kwargs as it's not intended as a constructor argument.
@@ -202,6 +216,7 @@ def _support_extended_types(field_type, field_value):
     return res
 
 
+@cached(cache=_is_supported_generic_cache, key=id)
 def _is_supported_generic(type_):
     not_str = not _issubclass_safe(type_, str)
     is_enum = _issubclass_safe(type_, Enum)

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,8 @@ setup(
         'marshmallow>=3.3.0,<4.0.0',
         'marshmallow-enum>=1.5.1,<2.0.0',
         'typing-inspect>=0.4.0',
-        'stringcase==1.2.0,<2.0.0'
+        'stringcase==1.2.0,<2.0.0',
+        'cachetools==4.0.0,<5.0.0'
     ],
     python_requires='>=3.6',
     extras_require={

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+pytest_plugins = [
+    'tests.fixtures'
+]

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,0 +1,10 @@
+import pytest
+# noinspection PyProtectedMember
+from dataclasses_json.core import _get_type_hints_cache, _is_supported_generic_cache, _user_overrides_cache
+
+
+@pytest.fixture(autouse=True)
+def clear_caches():
+    _is_supported_generic_cache.clear()
+    _user_overrides_cache.clear()
+    _get_type_hints_cache.clear()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,80 @@
+from tests.entities import (DataClassWithDataClass,
+                            DataClassWithList,
+                            DataClassX,
+                            DataClassXs)
+# noinspection PyProtectedMember
+from dataclasses_json.core import _get_type_hints_cache, _is_supported_generic_cache, _user_overrides_cache
+
+
+class TestCache:
+
+    def test_dataclass_with_xs_caches_class(self):
+        json_dataclass_with_xs = '{"xs": [{"x": 1}]}'
+        _ = DataClassXs.from_json(json_dataclass_with_xs)
+
+        # type hints for class and DataClassX cached
+        assert _get_type_hints_cache._Cache__currsize == 2
+        # supported generic called for List[DataClassX] and int
+        assert _is_supported_generic_cache._Cache__currsize == 2
+        # for the dataclasses
+        assert _user_overrides_cache._Cache__currsize == 2
+
+        # force cache hits
+        _ = DataClassXs.from_json(json_dataclass_with_xs)
+
+        assert _get_type_hints_cache._Cache__currsize == 2
+        assert _is_supported_generic_cache._Cache__currsize == 2
+        assert _user_overrides_cache._Cache__currsize == 2
+
+    def test_dataclass_with_x_caches_class(self):
+        json_dataclass_with_x = '{"x": 1}'
+        _ = DataClassX.from_json(json_dataclass_with_x)
+
+        # type hints for class cached
+        assert _get_type_hints_cache._Cache__currsize == 1
+        # supported generic called for int
+        assert _is_supported_generic_cache._Cache__currsize == 1
+        # for the dataclass
+        assert _user_overrides_cache._Cache__currsize == 1
+
+        # force cache hits
+        _ = DataClassX.from_json(json_dataclass_with_x)
+
+        assert _get_type_hints_cache._Cache__currsize == 1
+        assert _is_supported_generic_cache._Cache__currsize == 1
+        assert _user_overrides_cache._Cache__currsize == 1
+
+    def test_dataclass_with_list_caches_class(self):
+        json_dataclass_with_list = '{"xs": [1]}'
+        _ = DataClassWithList.from_json(json_dataclass_with_list)
+
+        # type hints for class cached
+        assert _get_type_hints_cache._Cache__currsize == 1
+        # supported generic called for List[int] and int itself
+        assert _is_supported_generic_cache._Cache__currsize == 2
+        # for the dataclass
+        assert _user_overrides_cache._Cache__currsize == 1
+
+        # force cache hits
+        _ = DataClassWithList.from_json(json_dataclass_with_list)
+
+        assert _get_type_hints_cache._Cache__currsize == 1
+        assert _is_supported_generic_cache._Cache__currsize == 2
+        assert _user_overrides_cache._Cache__currsize == 1
+
+    def test_nested_dataclass_caches_both_classes(self):
+        json_dataclass_with_dataclass = '{"dc_with_list": {"xs": [1]}}'
+        _ = DataClassWithDataClass.from_json(json_dataclass_with_dataclass)
+
+        assert _get_type_hints_cache._Cache__currsize == 2
+        # supported generic called for List[int] and int
+        assert _is_supported_generic_cache._Cache__currsize == 2
+        # for the dataclasses
+        assert _user_overrides_cache._Cache__currsize == 2
+
+        # force cache_hit
+        _ = DataClassWithDataClass.from_json(json_dataclass_with_dataclass)
+
+        assert _get_type_hints_cache._Cache__currsize == 2
+        assert _is_supported_generic_cache._Cache__currsize == 2
+        assert _user_overrides_cache._Cache__currsize == 2


### PR DESCRIPTION
* Same as https://github.com/lidatong/dataclasses-json/pull/148 but with cachetools and correct caching

id should work for caching as the three functions in questions always will receive a class as an argument which will have same identity always. Tests are passing and I added some too.

Load test with cache_size=1:

```
It took 39.030911922454834s to convert to dict
It took 30.857404708862305s to convert from dict
```

After introducing caching:
```
It took 41.651854038238525s to convert to dict
It took 16.02430510520935s to convert from dict
```

So about a 2x speedup when converting from dict.

I did write a load_test and profiled it to get to those results. There is great improvement but as you can see with the graph the performance is still quite bad for encoding to the dict. I was trying to somehow improve performance of the as_dict as well but didn't find a good solution. A cache wouldn't really work there as the hashing itself would mean you need to do json.dumps or something to have a consistent hash, which I think (i didn't try) would not improve performance. Find the screenshot of the callgraph attached. If you have some other ideas to fix it that would be great!

```python
from builtins import list
from random import randint
from typing import List, Dict, Any

from dataclasses_json import dataclass_json, DataClassJsonMixin
from time import time
from dataclasses import dataclass, field


@dataclass_json
@dataclass(frozen=True)
class AnotherNestedDataclass(DataClassJsonMixin):
    more_stuff: List[int] = field(default_factory=list)
    x: str = "a"
    y: str = "b"
    z: str = "c"
    dict_key: Dict[str, Any] = field(default_factory=dict)
    key: Any = "some_super_value"


@dataclass_json
@dataclass(frozen=True)
class NestedDataclass(DataClassJsonMixin):
    super_complicated: AnotherNestedDataclass = AnotherNestedDataclass()
    stuff: List[AnotherNestedDataclass] = field(default_factory=list)
    a: float = 0.0
    b: float = 0.0
    c: float = 0.0


@dataclass_json
@dataclass(frozen=True)
class BigDataclass(DataClassJsonMixin):
    nested: List[NestedDataclass] = field(default_factory=list)
    top_level_dict: Dict[str, Any] = field(default_factory=dict)


if __name__ == '__main__':
    to_parse: List[BigDataclass] = list()
    for i in range(1, 500):
        ints = [randint(1, 100)]*50
        nested_dataclass = NestedDataclass(stuff=[AnotherNestedDataclass(more_stuff=ints)]*50)
        to_parse.append(BigDataclass(nested=[nested_dataclass]*50))

    start = time()
    json = list(map(lambda dc: dc.to_dict(), to_parse))
    end = time()
    print(f"It took {end-start}s to convert to dict")

    start = time()

    list = list(map(BigDataclass.from_dict, json))

    end = time()

    print(f"It took {end-start}s to convert from dict")
```

profile results after caching:


![image](https://user-images.githubusercontent.com/6311872/74257322-f2f38c00-4cf4-11ea-9cb0-2a286bd17728.png)

![image](https://user-images.githubusercontent.com/6311872/74257361-043c9880-4cf5-11ea-947e-57202e2dd809.png)

@RunOrVeith
