### PR TITLE
datetime.timedelta support

### DIFF
--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -6,7 +6,7 @@ from collections import namedtuple
 from dataclasses import (MISSING, _is_dataclass_instance, fields,
                          is_dataclass  # type: ignore
                          )
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from enum import Enum
 from typing import Any, Collection, Dict, Mapping, Union, get_type_hints
@@ -33,6 +33,8 @@ class _ExtendedEncoder(json.JSONEncoder):
                 result = list(o)
         elif _isinstance_safe(o, datetime):
             result = o.timestamp()
+        elif _isinstance_safe(o, timedelta):
+            result = o.total_seconds()
         elif _isinstance_safe(o, UUID):
             result = str(o)
         elif _isinstance_safe(o, Enum):
@@ -189,6 +191,10 @@ def _support_extended_types(field_type, field_value):
         else:
             tz = datetime.now(timezone.utc).astimezone().tzinfo
             res = datetime.fromtimestamp(field_value, tz=tz)
+    elif _issubclass_safe(field_type, timedelta):
+        res = (field_value
+               if isinstance(field_value, timedelta)
+               else timedelta(seconds=field_value))
     elif _issubclass_safe(field_type, Decimal):
         res = (field_value
                if isinstance(field_value, Decimal)

--- a/dataclasses_json/mm.py
+++ b/dataclasses_json/mm.py
@@ -6,7 +6,7 @@ import sys
 from copy import deepcopy
 
 from dataclasses import MISSING, is_dataclass, fields as dc_fields
-from datetime import datetime
+from datetime import datetime, timedelta
 from decimal import Decimal
 from uuid import UUID
 from enum import Enum
@@ -38,6 +38,26 @@ class _TimestampField(fields.Field):
     def _deserialize(self, value, attr, data, **kwargs):
         if value is not None:
             return _timestamp_to_dt_aware(value)
+        else:
+            if not self.required:
+                return None
+            else:
+                raise ValidationError(self.default_error_messages["required"])
+
+
+class _TimedeltaField(fields.Field):
+    def _serialize(self, value, attr, obj, **kwargs):
+        if value is not None:
+            return value.total_seconds()
+        else:
+            if not self.required:
+                return None
+            else:
+                raise ValidationError(self.default_error_messages["required"])
+
+    def _deserialize(self, value, attr, data, **kwargs):
+        if value is not None:
+            return timedelta(seconds=value)
         else:
             if not self.required:
                 return None
@@ -127,6 +147,7 @@ TYPES = {
     float: fields.Float,
     bool: fields.Bool,
     datetime: _TimestampField,
+    timedelta: _TimedeltaField,
     UUID: fields.UUID,
     Decimal: fields.Decimal,
     CatchAllVar: fields.Dict,

--- a/tests/entities.py
+++ b/tests/entities.py
@@ -17,7 +17,7 @@ from uuid import UUID
 from marshmallow import fields
 
 import dataclasses_json
-from datetime import datetime
+from datetime import datetime, timedelta
 from dataclasses_json import (DataClassJsonMixin, LetterCase, dataclass_json)
 
 A = TypeVar('A')
@@ -235,6 +235,12 @@ class DataClassOptional:
 @dataclass
 class DataClassWithOptionalDatetime:
     a: Optional[datetime]
+
+
+@dataclass_json
+@dataclass
+class DataClassWithOptionalTimedelta:
+    a: Optional[timedelta]
 
 
 @dataclass_json

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 from decimal import Decimal
 from uuid import UUID
 
@@ -14,6 +14,7 @@ from tests.entities import (DataClassBoolImmutableDefault,
                             DataClassWithNestedNewType, DataClassWithNewType,
                             DataClassWithOptional,
                             DataClassWithOptionalDatetime,
+                            DataClassWithOptionalTimedelta,
                             DataClassWithOptionalDecimal,
                             DataClassWithOptionalNested,
                             DataClassWithOptionalUuid, DataClassWithUuid, Id,
@@ -41,6 +42,12 @@ class TestGenericExtendedTypes:
         dt = datetime(2018, 11, 17, 16, 55, 28, 456753, tzinfo=timezone.utc)
         dc = DataClassWithOptionalDatetime(dt)
         assert (DataClassWithOptionalDatetime.from_json(dc.to_json())
+                == dc)
+
+    def test_optional_timedelta(self):
+        td = timedelta(days=14, hours=8, seconds=8)
+        dc = DataClassWithOptionalTimedelta(td)
+        assert (DataClassWithOptionalTimedelta.from_json(dc.to_json())
                 == dc)
 
     def test_optional_decimal(self):

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 from dataclasses import dataclass, field
 import sys
 
@@ -13,6 +13,12 @@ from dataclasses_json.mm import _IsoField
 @dataclass
 class DataClassWithDatetime:
     created_at: datetime
+
+
+@dataclass_json
+@dataclass
+class DataClassWithTimedelta:
+    delay: timedelta
 
 
 if sys.version_info >= (3, 7):
@@ -46,6 +52,11 @@ class TestTime:
     dc_ts_json = f'{{"created_at": {ts}}}'
     dc_ts = DataClassWithDatetime(datetime.fromtimestamp(ts, tz=tz))
 
+    td = timedelta(days=14, hours=8, seconds=8)
+    ts = td.total_seconds()
+    dc_td_json = f'{{"delay": {ts}}}'
+    dc_td = DataClassWithTimedelta(timedelta(seconds=ts))
+
     if sys.version_info >= (3, 7):
         iso = dt.isoformat()
         dc_iso_json = f'{{"created_at": "{iso}"}}'
@@ -56,6 +67,12 @@ class TestTime:
 
     def test_datetime_decode(self):
         assert (DataClassWithDatetime.from_json(self.dc_ts_json) == self.dc_ts)
+
+    def test_timedelta_encode(self):
+        assert (self.dc_td.to_json() == self.dc_td_json)
+
+    def test_timedelta_decode(self):
+        assert (DataClassWithTimedelta.from_json(self.dc_td_json) == self.dc_td)
 
     @pytest.mark.skipif(sys.version_info < (3, 7),
                         reason="requires python3.7")
@@ -75,6 +92,14 @@ class TestTime:
     def test_datetime_schema_decode(self):
         assert (DataClassWithDatetime.schema().loads(self.dc_ts_json)
                 == self.dc_ts)
+
+    def test_timedelta_schema_encode(self):
+        assert (DataClassWithTimedelta.schema().dumps(self.dc_td)
+                == self.dc_td_json)
+
+    def test_timedelta_schema_decode(self):
+        assert (DataClassWithTimedelta.schema().loads(self.dc_td_json)
+                == self.dc_td)
 
     @pytest.mark.skipif(sys.version_info < (3, 7),
                         reason="requires python3.7")


### PR DESCRIPTION
Added support of `datetime.timedelta`:
encode: `timedelta.total_seconds`, decode: `lambda s: timedelta(seconds=s)`