### PR TITLE
fix cache using id -> hash conflicts for classes with the same name

### DIFF
--- a/dataclasses_json/api.py
+++ b/dataclasses_json/api.py
@@ -1,5 +1,6 @@
 import abc
 import json
+import uuid
 from enum import Enum
 from typing import (Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar,
                     Union)
@@ -35,6 +36,10 @@ class DataClassJsonMixin(abc.ABC):
     As with other ABCs, it should not be instantiated directly.
     """
     dataclass_json_config = None
+    _dataclass_hash: str
+
+    def __init_subclass__(cls, **kwargs):
+        cls._dataclass_hash = str(uuid.uuid4())
 
     def to_json(self,
                 *,
@@ -150,6 +155,7 @@ def _process_class(cls, letter_case, undefined):
     cls.to_dict = DataClassJsonMixin.to_dict
     cls.from_dict = classmethod(DataClassJsonMixin.from_dict.__func__)
     cls.schema = classmethod(DataClassJsonMixin.schema.__func__)
+    cls._dataclass_hash = str(uuid.uuid4())
 
     cls.__init__ = _handle_undefined_parameters_safe(cls, kvs=(), usage="init")
     # register cls as a virtual subclass of DataClassJsonMixin

--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -57,7 +57,14 @@ confs = ['encoder', 'decoder', 'mm_field', 'letter_case']
 FieldOverride = namedtuple('FieldOverride', confs)
 
 
-@cached(cache=_user_overrides_cache, key=repr)
+def _hash_key(cls):
+    if hasattr(cls, '_dataclass_hash'):
+        return cls._dataclass_hash
+    else:
+        return repr(cls)
+
+
+@cached(cache=_user_overrides_cache, key=_hash_key)
 def _user_overrides_or_exts(cls) -> Dict[str, FieldOverride]:
     overrides = {}
     # overrides at the class-level
@@ -128,7 +135,7 @@ def _decode_letter_case_overrides(field_names, overrides):
     return names
 
 
-@cached(cache=_get_type_hints_cache, key=repr)
+@cached(cache=_get_type_hints_cache, key=_hash_key)
 def _get_type_hints_cached(cls):
     return get_type_hints(cls)
 
@@ -237,7 +244,7 @@ def _support_extended_types(field_type, field_value):
     return res
 
 
-@cached(cache=_is_supported_generic_cache, key=repr)
+@cached(cache=_is_supported_generic_cache, key=_hash_key)
 def _is_supported_generic(type_):
     not_str = not _issubclass_safe(type_, str)
     is_enum = _issubclass_safe(type_, Enum)

--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -57,7 +57,7 @@ confs = ['encoder', 'decoder', 'mm_field', 'letter_case']
 FieldOverride = namedtuple('FieldOverride', confs)
 
 
-@cached(cache=_user_overrides_cache, key=id)
+@cached(cache=_user_overrides_cache, key=repr)
 def _user_overrides_or_exts(cls) -> Dict[str, FieldOverride]:
     overrides = {}
     # overrides at the class-level
@@ -128,7 +128,7 @@ def _decode_letter_case_overrides(field_names, overrides):
     return names
 
 
-@cached(cache=_get_type_hints_cache, key=id)
+@cached(cache=_get_type_hints_cache, key=repr)
 def _get_type_hints_cached(cls):
     return get_type_hints(cls)
 
@@ -237,7 +237,7 @@ def _support_extended_types(field_type, field_value):
     return res
 
 
-@cached(cache=_is_supported_generic_cache, key=id)
+@cached(cache=_is_supported_generic_cache, key=repr)
 def _is_supported_generic(type_):
     not_str = not _issubclass_safe(type_, str)
     is_enum = _issubclass_safe(type_, Enum)

--- a/scripts/load_test.py
+++ b/scripts/load_test.py
@@ -1,0 +1,56 @@
+from builtins import list
+from random import randint
+from typing import List, Dict, Any
+
+from dataclasses_json import dataclass_json, DataClassJsonMixin
+from time import time
+from dataclasses import dataclass, field
+
+
+@dataclass_json
+@dataclass(frozen=True)
+class AnotherNestedDataclass(DataClassJsonMixin):
+    more_stuff: List[int] = field(default_factory=list)
+    x: str = "a"
+    y: str = "b"
+    z: str = "c"
+    dict_key: Dict[str, Any] = field(default_factory=dict)
+    key: Any = "some_super_value"
+
+
+@dataclass_json
+@dataclass(frozen=True)
+class NestedDataclass(DataClassJsonMixin):
+    super_complicated: AnotherNestedDataclass = AnotherNestedDataclass()
+    stuff: List[AnotherNestedDataclass] = field(default_factory=list)
+    a: float = 0.0
+    b: float = 0.0
+    c: float = 0.0
+
+
+@dataclass_json
+@dataclass(frozen=True)
+class BigDataclass(DataClassJsonMixin):
+    nested: List[NestedDataclass] = field(default_factory=list)
+    top_level_dict: Dict[str, Any] = field(default_factory=dict)
+
+
+if __name__ == '__main__':
+    to_parse: List[BigDataclass] = list()
+    for i in range(1, 100):
+        ints = [randint(1, 100)]*50
+        nested_dataclass = NestedDataclass(stuff=[AnotherNestedDataclass(more_stuff=ints)]*50)
+        to_parse.append(BigDataclass(nested=[nested_dataclass]*50))
+
+    start = time()
+    json = list(map(lambda dc: dc.to_dict(), to_parse))
+    end = time()
+    print(f"It took {end-start}s to convert to dict")
+
+    start = time()
+
+    list = list(map(BigDataclass.from_dict, json))
+
+    end = time()
+
+    print(f"It took {end-start}s to convert from dict")

--- a/tests/test_hash_key.py
+++ b/tests/test_hash_key.py
@@ -1,0 +1,55 @@
+from dataclasses import dataclass
+from typing import List, Tuple, Any
+
+from dataclasses_json import DataClassJsonMixin, dataclass_json
+from dataclasses_json.core import _hash_key
+
+
+def test_hash_key_dataclass():
+
+    @dataclass()
+    class DataclassWithMixin(DataClassJsonMixin):
+        a: str
+
+    assert _hash_key(DataclassWithMixin) == DataclassWithMixin._dataclass_hash
+
+    @dataclass_json()
+    @dataclass()
+    class DataClassWithoutMixin:
+        b: str
+
+    assert _hash_key(DataClassWithoutMixin) == DataClassWithoutMixin._dataclass_hash
+
+
+def test_hash_key_type():
+
+    assert _hash_key(List[str]) == repr(List[str])
+    assert _hash_key(List) == repr(List)
+    assert _hash_key(List) != _hash_key(List[str])
+    assert _hash_key(List[Any]) != _hash_key(List[str])
+
+    assert _hash_key(Tuple) == repr(Tuple)
+    assert _hash_key(Tuple[int, int]) == repr(Tuple[int, int])
+    assert _hash_key(Tuple) != repr(Tuple[int, int])
+    assert _hash_key(Tuple[int, str]) != repr(Tuple[int, int])
+
+    assert _hash_key(str) != _hash_key(int)
+
+
+def test_hash_key_classes():
+    class A:
+        A: str
+
+    hashkey_original_a = _hash_key(A)
+
+    class B:
+        b: str
+
+    assert _hash_key(A) != _hash_key(B)
+
+    class A:
+        redefined: str
+
+    # this is the only possible behavior. We do not care about has conflicts here as non-json-encodable so nothing will be cached anyways.
+    assert _hash_key(A) == hashkey_original_a
+

--- a/tests/test_hash_key.py
+++ b/tests/test_hash_key.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from typing import List, Tuple, Any
 
 from dataclasses_json import DataClassJsonMixin, dataclass_json
+# noinspection PyProtectedMember
 from dataclasses_json.core import _hash_key
 
 

--- a/tests/test_multiple_classes_same_name.py
+++ b/tests/test_multiple_classes_same_name.py
@@ -1,0 +1,42 @@
+from dataclasses import dataclass
+from dataclasses_json import dataclass_json, LetterCase, DataClassJsonMixin
+
+
+def test_multiple_classes_same_name():
+
+    @dataclass_json(letter_case=LetterCase.CAMEL)
+    @dataclass(frozen=True)
+    class Camel(DataClassJsonMixin):
+        test_field: float
+
+    @dataclass_json(letter_case=LetterCase.SNAKE)
+    @dataclass(frozen=True)
+    class Snake(DataClassJsonMixin):
+        test_field: float
+
+
+    camel1 = Camel(test_field=5)
+    snake1 = Snake(test_field=10)
+
+    assert camel1.to_dict()['testField'] == camel1.test_field
+    assert snake1.to_dict()['test_field'] == snake1.test_field
+
+    # redefine classes with the same name to replace current object at id(Camel)
+    @dataclass_json(letter_case=LetterCase.CAMEL)
+    @dataclass(frozen=True)
+    class Camel(DataClassJsonMixin):
+        test_field: float
+
+
+    @dataclass_json(letter_case=LetterCase.SNAKE)
+    @dataclass(frozen=True)
+    class Snake(DataClassJsonMixin):
+        test_field: float
+
+    camel1 = Camel(test_field=5)
+    snake1 = Snake(test_field=10)
+    print('camel', camel1.to_json())
+    print('snake', snake1.to_json())
+
+    assert camel1.to_dict()['testField'] == camel1.test_field
+    assert snake1.to_dict()['test_field'] == snake1.test_field

--- a/tests/test_multiple_classes_same_name.py
+++ b/tests/test_multiple_classes_same_name.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+
 from dataclasses_json import dataclass_json, LetterCase, DataClassJsonMixin
 
 
@@ -13,7 +14,6 @@ def test_multiple_classes_same_name():
     @dataclass(frozen=True)
     class Snake(DataClassJsonMixin):
         test_field: float
-
 
     camel1 = Camel(test_field=5)
     snake1 = Snake(test_field=10)
@@ -35,8 +35,67 @@ def test_multiple_classes_same_name():
 
     camel1 = Camel(test_field=5)
     snake1 = Snake(test_field=10)
-    print('camel', camel1.to_json())
-    print('snake', snake1.to_json())
 
     assert camel1.to_dict()['testField'] == camel1.test_field
     assert snake1.to_dict()['test_field'] == snake1.test_field
+
+
+def test_multiple_classes_same_name_different_lettercase():
+
+    @dataclass_json(letter_case=LetterCase.CAMEL)
+    @dataclass(frozen=True)
+    class Camel(DataClassJsonMixin):
+        test_field: float
+
+    @dataclass_json(letter_case=LetterCase.SNAKE)
+    @dataclass(frozen=True)
+    class Snake(DataClassJsonMixin):
+        test_field: float
+
+    camel1 = Camel(test_field=5)
+    snake1 = Snake(test_field=10)
+
+    assert camel1.to_dict()['testField'] == camel1.test_field
+    assert snake1.to_dict()['test_field'] == snake1.test_field
+
+    # redefine classes with the same name to replace current object at id(Camel)
+    @dataclass_json(letter_case=LetterCase.CAMEL)
+    @dataclass(frozen=True)
+    class Camel(DataClassJsonMixin):
+        test_field: float
+
+    # now we define the class with a different lettercase
+    @dataclass_json(letter_case=LetterCase.CAMEL)
+    @dataclass(frozen=True)
+    class Snake(DataClassJsonMixin):
+        test_field: float
+
+    camel1 = Camel(test_field=5)
+    snake1 = Snake(test_field=10)
+
+    assert camel1.to_dict()['testField'] == camel1.test_field
+    assert snake1.to_dict()['testField'] == snake1.test_field
+
+
+def test_multiple_classes_same_name_different_subtype_works():
+
+    class Subtype:
+        test_field: float = 5
+
+    original_subtype = Subtype()
+
+    @dataclass_json(letter_case=LetterCase.CAMEL)
+    @dataclass(frozen=True)
+    class OriginalADataclass(DataClassJsonMixin):
+        test_field: Subtype
+
+    original = OriginalADataclass(test_field=original_subtype)
+
+    class Subtype:
+        test_field: float = 10
+
+    new_subtype = Subtype()
+
+    new = OriginalADataclass(test_field=new_subtype)
+
+    assert original.to_dict()['testField'] != new.to_dict()['testField']


### PR DESCRIPTION
Unfortunately my previous cache pr didn't work when it came to overwriting classes with the same name, see the test case I added that fails on the previous version and passes now.

This is because the previous memory address is free again after overwriting a class with a class with the same name and a new assignment will (possibly ? not sure about cpythons internals here 😄 ) reuse it.

This uses repr and an injected class field instead.

Performance on the load_test (I committed that feel free to remove it/move it around):

No cache:
```
/Applications/miniconda3/envs/dataclasses-json/bin/python /Users/ddraper/dev/dataclasses-json/load_test.py
It took 42.135189056396484s to convert to dict
It took 32.14417791366577s to convert from dict
```

With cache and _dataclass_hash as the key:
```
/Applications/miniconda3/envs/dataclasses-json/bin/python /Users/ddraper/dev/dataclasses-json/scripts/load_test.py
It took 40.158539056777954s to convert to dict
It took 19.082113027572632s to convert from dict

Process finished with exit code 0
```