### PR TITLE
Fix dataclass_json docstring

### DIFF
--- a/dataclasses_json/api.py
+++ b/dataclasses_json/api.py
@@ -124,7 +124,7 @@ def dataclass_json(_cls=None, *, letter_case=None,
     decorators. See example below:
 
     @dataclass_json
-    @dataclass_json(letter_case=Lettercase.CAMEL)
+    @dataclass_json(letter_case=LetterCase.CAMEL)
     class Example:
         ...
     """


### PR DESCRIPTION
The docstring was referring `Lettercase.CAMEL` instead of `LetterCase.CAMEL`. 
I lost 5 minutes on this as my IDE couldn't import the enum, so I though it might be worth fixing for others.