### PR TITLE
Fix field name override when letter_case is set with the decorator

### DIFF
--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -67,7 +67,7 @@ def _user_overrides_or_exts(cls):
 
     overrides = {}
     for field in fields(cls):
-        field_config = field.metadata.get('dataclasses_json', {})
+        field_config = {}
         # first apply global overrides or extensions
         field_metadata = global_metadata[field.name]
         if 'encoder' in field_metadata:
@@ -79,6 +79,7 @@ def _user_overrides_or_exts(cls):
         # then apply class-level overrides or extensions
         field_config.update(cls_config)
         # last apply field-level overrides or extensions
+        field_config.update(field.metadata.get('dataclasses_json', {}))
         overrides[field.name] = FieldOverride(*map(field_config.get, confs))
     return overrides
 

--- a/tests/test_letter_case.py
+++ b/tests/test_letter_case.py
@@ -49,6 +49,13 @@ class FieldNamePerson:
     given_name: str = field(metadata=config(field_name='givenName'))
 
 
+@dataclass_json(letter_case=LetterCase.CAMEL)
+@dataclass
+class CamelCasePersonWithOverride:
+    given_name: str
+    years_on_earth: str = field(metadata=config(field_name='age'))
+
+
 class TestLetterCase:
     def test_camel_encode(self):
         assert CamelCasePerson('Alice').to_json() == '{"givenName": "Alice"}'
@@ -85,8 +92,18 @@ class TestLetterCase:
         assert FieldNamePerson.from_json(
             '{"givenName": "Alice"}') == FieldNamePerson('Alice')
 
+    def test_camel_with_override_encode(self):
+        assert CamelCasePersonWithOverride(
+            'Alice', 10).to_json() == '{"givenName": "Alice", "age": 10}'
+
+    def test_camel_with_override_decode(self):
+        expected = CamelCasePersonWithOverride('Alice', 10)
+        assert CamelCasePersonWithOverride.from_json(
+            '{"givenName": "Alice", "age": 10}') == expected
+
     def test_from_dict(self):
-        assert CamelCasePerson.from_dict({'givenName': 'Alice'}) == CamelCasePerson('Alice')
+        assert CamelCasePerson.from_dict(
+            {'givenName': 'Alice'}) == CamelCasePerson('Alice')
 
     def test_to_dict(self):
         assert {'givenName': 'Alice'} == CamelCasePerson('Alice').to_dict()


### PR DESCRIPTION
Closes #160 

This PR prioritizes the field-level metadata overrides so that classes such as the following work as expected:

```python
@dataclass_json(letter_case=LetterCase.CAMEL)
@dataclass
class CamelCasePersonWithOverride:
    given_name: str
    years_on_earth: str = field(metadata=config(field_name='age'))
```