### PR TITLE
Allow fields to be excluded from encoding

### DIFF
--- a/dataclasses_json/__init__.py
+++ b/dataclasses_json/__init__.py
@@ -2,5 +2,5 @@
 from dataclasses_json.api import (DataClassJsonMixin,
                                   LetterCase,
                                   dataclass_json)
-from dataclasses_json.cfg import config, global_config
+from dataclasses_json.cfg import config, global_config, Exclude
 from dataclasses_json.undefined import CatchAll, Undefined

--- a/dataclasses_json/cfg.py
+++ b/dataclasses_json/cfg.py
@@ -1,9 +1,23 @@
 import functools
-from typing import (Callable, Dict, Optional, Union)
+from typing import Callable, Dict, NamedTuple, Optional, TypeVar, Union
 
 from marshmallow.fields import Field as MarshmallowField
 
 from dataclasses_json.undefined import Undefined, UndefinedParameterError
+
+T = TypeVar("T")
+
+
+class _Exclude(NamedTuple):
+    """
+    Whether or not the field should be excluded when encoded
+    """
+
+    ALWAYS: Callable[[T], bool] = lambda _: True
+    NEVER: Callable[[T], bool] = lambda _: False
+
+
+Exclude = _Exclude()
 
 
 # TODO: add warnings?
@@ -35,7 +49,9 @@ def config(metadata: dict = None, *,
            mm_field: MarshmallowField = None,
            letter_case: Callable[[str], str] = None,
            undefined: Optional[Union[str, Undefined]] = None,
-           field_name: str = None) -> Dict[str, dict]:
+           field_name: str = None,
+           exclude: Optional[Callable[[str, T], bool]] = None,
+           ) -> Dict[str, dict]:
     if metadata is None:
         metadata = {}
 
@@ -74,5 +90,8 @@ def config(metadata: dict = None, *,
             undefined = Undefined[undefined.upper()]
 
         lib_metadata['undefined'] = undefined
+
+    if exclude is not None:
+        lib_metadata['exclude'] = exclude
 
     return metadata

--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -48,7 +48,7 @@ class _ExtendedEncoder(json.JSONEncoder):
 
 
 def _user_overrides_or_exts(cls):
-    confs = ['encoder', 'decoder', 'mm_field', 'letter_case']
+    confs = ['encoder', 'decoder', 'mm_field', 'letter_case', 'exclude']
     FieldOverride = namedtuple('FieldOverride', confs)
 
     global_metadata = defaultdict(dict)
@@ -94,6 +94,11 @@ def _encode_overrides(kvs, overrides, encode_json=False):
     override_kvs = {}
     for k, v in kvs.items():
         if k in overrides:
+            exclude = overrides[k].exclude
+            # If the exclude predicate returns true, the key should be
+            #  excluded from encoding, so skip the rest of the loop
+            if exclude and exclude(v):
+                continue
             letter_case = overrides[k].letter_case
             original_key = k
             k = letter_case(k) if letter_case is not None else k

--- a/tests/test_exclude.py
+++ b/tests/test_exclude.py
@@ -1,0 +1,51 @@
+from dataclasses import dataclass, field
+
+from dataclasses_json.api import DataClassJsonMixin, config
+from dataclasses_json.cfg import Exclude
+
+
+@dataclass
+class EncodeExclude(DataClassJsonMixin):
+    public_field: str
+    private_field: str = field(metadata=config(exclude=Exclude.ALWAYS))
+
+
+@dataclass
+class EncodeInclude(DataClassJsonMixin):
+    public_field: str
+    private_field: str = field(metadata=config(exclude=Exclude.NEVER))
+
+
+@dataclass
+class EncodeCustom(DataClassJsonMixin):
+    public_field: str
+    sensitive_field: str = field(
+        metadata=config(exclude=lambda v: v.startswith("secret"))
+    )
+
+
+def test_exclude():
+    dclass = EncodeExclude(public_field="public", private_field="private")
+    encoded = dclass.to_dict()
+    assert "public_field" in encoded
+    assert "private_field" not in encoded
+
+
+def test_include():
+    dclass = EncodeInclude(public_field="public", private_field="private")
+    encoded = dclass.to_dict()
+    assert "public_field" in encoded
+    assert "private_field" in encoded
+    assert encoded["private_field"] == "private"
+
+
+def test_custom_action_included():
+    dclass = EncodeCustom(public_field="public", sensitive_field="notsecret")
+    encoded = dclass.to_dict()
+    assert "sensitive_field" in encoded
+
+
+def test_custom_action_excluded():
+    dclass = EncodeCustom(public_field="public", sensitive_field="secret")
+    encoded = dclass.to_dict()
+    assert "sensitive_field" not in encoded


### PR DESCRIPTION
Introduce an `encode_action` field config parameter. When set to exclude
a field, the encoder will not include it in the encoded dictionary.

The config parameter can also accept a callback that receives the
key-value pair being encoded, allowing for more-granular control of the
exclusion check.

I'm very much open to modifying this to fit the goals of the library.  Also, I'm not sure how one goes about updating the documentation, but, if you point me in the right direction, I'm more than happy to update it as well.

Fixes #200 