### PR TITLE
Move FieldOverrides creation outside of _user_overrides_or_exts

### DIFF
--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -11,7 +11,6 @@ from dataclasses import (MISSING,
 from datetime import datetime, timezone
 from decimal import Decimal
 from enum import Enum
-from functools import lru_cache
 from typing import Any, Collection, Mapping, Union, get_type_hints
 from uuid import UUID
 
@@ -25,6 +24,9 @@ from dataclasses_json.utils import (_get_type_cons,
                                     _issubclass_safe)
 
 Json = Union[dict, list, str, int, float, bool, None]
+
+confs = ['encoder', 'decoder', 'mm_field', 'letter_case', 'exclude']
+FieldOverride = namedtuple('FieldOverride', confs)
 
 
 class _ExtendedEncoder(json.JSONEncoder):
@@ -48,11 +50,7 @@ class _ExtendedEncoder(json.JSONEncoder):
         return result
 
 
-@lru_cache(maxsize=128)
 def _user_overrides_or_exts(cls):
-    confs = ['encoder', 'decoder', 'mm_field', 'letter_case', 'exclude']
-    FieldOverride = namedtuple('FieldOverride', confs)
-
     global_metadata = defaultdict(dict)
     encoders = cfg.global_config.encoders
     decoders = cfg.global_config.decoders

--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -11,6 +11,7 @@ from dataclasses import (MISSING,
 from datetime import datetime, timezone
 from decimal import Decimal
 from enum import Enum
+from functools import lru_cache
 from typing import Any, Collection, Mapping, Union, get_type_hints
 from uuid import UUID
 
@@ -47,6 +48,7 @@ class _ExtendedEncoder(json.JSONEncoder):
         return result
 
 
+@lru_cache(maxsize=128)
 def _user_overrides_or_exts(cls):
     confs = ['encoder', 'decoder', 'mm_field', 'letter_case', 'exclude']
     FieldOverride = namedtuple('FieldOverride', confs)


### PR DESCRIPTION
Hello! I have a fairly large dataset (~7 million entries) that I am deserializing with this library, but unfortunately deserialization has become a bottleneck. After a bit of profiling, it looks like the majority of runtime is spent in `_user_overrides_or_exts` within `core.py`. More specifically, `_user_overrides_or_exts` creates a `FieldOverride` `NamedTuple` every time the method is called.

While the namedtuple creation may seem trivial, the runtime adds up when deserializing a large dataset. Below is a sample from my `cProfile` run:
```    Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
  7171820    8.270    0.000 5588.569    0.001 schema.py:691(load)
  7171820   45.781    0.000 5580.299    0.001 schema.py:807(_do_load)
  7171820   15.652    0.000 5046.081    0.001 schema.py:1071(_invoke_load_processors)
 14343640   27.048    0.000 5030.430    0.000 schema.py:1192(_invoke_processors)
  7171820   12.661    0.000 4999.333    0.001 mm.py:325(make_instance)
  7171820  154.023    0.000 4986.672    0.001 core.py:101(_decode_dataclass)
  7171821   89.148    0.000 2775.553    0.000 core.py:47(_user_overrides)
  7172281  114.348    0.000 2603.727    0.000 __init__.py:357(namedtuple)
```

Is there a reason I'm missing that `FieldOverrides` is created within the `_user_overrides_or_exts` function instead of once at the top of the file? By only creating `FieldOverrides` once, this saves a ton of runtime and improves the performance of my current use case by more than an order of magnitude.

Thank you!