### PR TITLE
Fix type annotation for the exclude config arg

### DIFF
--- a/dataclasses_json/cfg.py
+++ b/dataclasses_json/cfg.py
@@ -50,7 +50,7 @@ def config(metadata: dict = None, *,
            letter_case: Callable[[str], str] = None,
            undefined: Optional[Union[str, Undefined]] = None,
            field_name: str = None,
-           exclude: Optional[Callable[[str, T], bool]] = None,
+           exclude: Optional[Callable[[T], bool]] = None,
            ) -> Dict[str, dict]:
     if metadata is None:
         metadata = {}


### PR DESCRIPTION
It seems that, when we dropped the second predicate parameter, we missed this occurrence.