### PR TITLE
fix: vendor-in code from stringcase

### DIFF
--- a/dataclasses_json/api.py
+++ b/dataclasses_json/api.py
@@ -4,9 +4,8 @@ from enum import Enum
 from typing import (Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar,
                     Union)
 
-from stringcase import (camelcase, pascalcase, snakecase,
-                        spinalcase)  # type: ignore
-
+from dataclasses_json.stringcase import (camelcase, pascalcase, snakecase,
+                                         spinalcase)  # type: ignore
 from dataclasses_json.cfg import config
 from dataclasses_json.core import (Json, _ExtendedEncoder, _asdict,
                                    _decode_dataclass)

--- a/dataclasses_json/stringcase.py
+++ b/dataclasses_json/stringcase.py
@@ -1,0 +1,108 @@
+# Copyright © 2015-2018 Taka Okunishi <okunishinishi@gmail.com>.
+# Copyright © 2020 Louis-Philippe Véronneau <pollo@debian.org>
+
+import re
+
+
+def uplowcase(string, case):
+    """Convert string into upper or lower case.
+
+    Args:
+        string: String to convert.
+
+    Returns:
+        string: Uppercase or lowercase case string.
+
+    """
+    if case == 'up':
+        return str(string).upper()
+    elif case == 'low':
+        return str(string).lower()
+
+
+def capitalcase(string):
+    """Convert string into capital case.
+    First letters will be uppercase.
+
+    Args:
+        string: String to convert.
+
+    Returns:
+        string: Capital case string.
+
+    """
+
+    string = str(string)
+    if not string:
+        return string
+    return uplowcase(string[0], 'up') + string[1:]
+
+
+def camelcase(string):
+    """ Convert string into camel case.
+
+    Args:
+        string: String to convert.
+
+    Returns:
+        string: Camel case string.
+
+    """
+
+    string = re.sub(r"^[\-_\.]", '', str(string))
+    if not string:
+        return string
+    return uplowcase(string[0], 'low') \
+        + re.sub(r"[\-_\.\s]([a-z])",
+                 lambda matched: uplowcase(matched.group(1), 'up'),
+                 string[1:])
+
+
+def snakecase(string):
+    """Convert string into snake case.
+    Join punctuation with underscore
+
+    Args:
+        string: String to convert.
+
+    Returns:
+        string: Snake cased string.
+
+    """
+
+    string = re.sub(r"[\-\.\s]", '_', str(string))
+    if not string:
+        return string
+    return uplowcase(string[0], 'low') \
+        + re.sub(r"[A-Z]",
+                 lambda matched: '_' + uplowcase(matched.group(0), 'low'),
+                 string[1:])
+
+
+def spinalcase(string):
+    """Convert string into spinal case.
+    Join punctuation with hyphen.
+
+    Args:
+        string: String to convert.
+
+    Returns:
+        string: Spinal cased string.
+
+    """
+
+    return re.sub(r"_", "-", snakecase(string))
+
+
+def pascalcase(string):
+    """Convert string into pascal case.
+
+    Args:
+        string: String to convert.
+
+    Returns:
+        string: Pascal case string.
+
+    """
+
+    return capitalcase(camelcase(string))

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,7 @@ setup(
         'dataclasses;python_version=="3.6"',
         'marshmallow>=3.3.0,<4.0.0',
         'marshmallow-enum>=1.5.1,<2.0.0',
-        'typing-inspect>=0.4.0',
-        'stringcase==1.2.0,<2.0.0'
+        'typing-inspect>=0.4.0'
     ],
     python_requires='>=3.6',
     extras_require={


### PR DESCRIPTION
Closes #236.

The python-stringcase dependency this package has is very badly maintained:
  * There are no releases.
  * There are no git tags.
  * The last release on PyPi was 3 years ago, although internal version
    numbers have been bumped since then.
  * The project seems somewhat dormant, if not abandonned.

Having it as a dependency is thus a liability and makes this library hard to package in Linux distributions, as packaging badly maintained libraries is no fun.

Since the code used is actually very simple, it makes sense to vendor it in and not depend on it anymore.

Note that I am not the author of the majority of the code in this patch and mainly did some glue work. Credit and copyright attributions (under the MIT) should be attributed to the original author, Taka Okunishi <okunishinishi@gmail.com>. I tried to make that clear by adding a copyright header to the new stringcase.py file.

The original code can be found at: https://raw.githubusercontent.com/okunishinishi/python-stringcase/master/stringcase.py

I ran the testsuite and `flake8` and everything passes. Happy to make any modifications required :)