### PR TITLE
Add `tuple` to the list of fields.

### DIFF
--- a/dataclasses_json/mm.py
+++ b/dataclasses_json/mm.py
@@ -123,6 +123,7 @@ TYPES = {
     typing.Any: fields.Raw,
     dict: fields.Dict,
     list: fields.List,
+    tuple: fields.Tuple,
     str: fields.Str,
     int: fields.Int,
     float: fields.Float,


### PR DESCRIPTION
Without it, getting a schema from a type including `typing.Tuple` returns a warning (as `typing.Tuple.__origin__` is `tuple`).