### PR TITLE
Fix unsupported generics for Python 3.6

### DIFF
--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -128,7 +128,7 @@ def _decode_letter_case_overrides(field_names, overrides):
 
 
 def _decode_dataclass(cls, kvs, infer_missing):
-    if isinstance(kvs, cls):
+    if _isinstance_safe(kvs, cls):
         return kvs
     overrides = _user_overrides_or_exts(cls)
     kvs = {} if kvs is None and infer_missing else kvs

--- a/dataclasses_json/utils.py
+++ b/dataclasses_json/utils.py
@@ -49,6 +49,11 @@ def _hasargs(type_, *args):
         res = all(arg in type_.__args__ for arg in args)
     except AttributeError:
         return False
+    except TypeError:
+        if (type_.__args__ is None):
+            return False
+        else:
+            raise
     else:
         return res
 

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
             'hypothesis',
             'portray',
             'flake8',
+            'types-dataclasses;python_version=="3.6"',
             'simplejson'
         ]
     },

--- a/tests/test_unsupported_generics.py
+++ b/tests/test_unsupported_generics.py
@@ -1,0 +1,43 @@
+from dataclasses import dataclass
+from typing import TypeVar, Generic
+from dataclasses_json import DataClassJsonMixin
+
+
+T = TypeVar('T')
+class ContainerCls(Generic[T]):
+    value: T
+    required: bool
+
+@dataclass
+class DataClassWithUnsupscriptedGeneric(DataClassJsonMixin):
+    a: ContainerCls
+
+@dataclass
+class DataClassWithSupscriptedGeneric(DataClassJsonMixin):
+    a: ContainerCls[int]
+
+@dataclass
+class DataClassWithParameterizedGeneric(DataClassJsonMixin, Generic[T]):
+    a: ContainerCls[T]
+
+
+class TestUnsupportedGenerics:
+    def test_unsupscripted(self):
+        j = '{ "a": { "value": "test", "required": true } }'
+        dc = DataClassWithUnsupscriptedGeneric.from_json(j)
+        assert dc.a == dict(value='test', required=True)
+    
+    def test_supscripted(self):
+        j = '{ "a": { "value": 5, "required": false } }'
+        dc = DataClassWithSupscriptedGeneric.from_json(j)
+        assert dc.a == dict(value=5, required=False)
+    
+    def test_parameterized_unsupscripted(self):
+        j = '{ "a": { "value": "test", "required": true } }'
+        dc = DataClassWithParameterizedGeneric.from_json(j)
+        assert dc.a == dict(value='test', required=True)
+    
+    def test_parameterized_supscripted(self):
+        j = '{ "a": { "value": "test", "required": true } }'
+        dc = DataClassWithParameterizedGeneric[str].from_json(j)
+        assert dc.a == dict(value='test', required=True)


### PR DESCRIPTION
### Changes:
 - Added tests to detect #300 (two fail on Python 3.6)
   * Unsupscripted Generics
   * Supscripted Generics
   * Parameterized Generics in Unsupscritped Generic class
   * Parameterized Generics in Supscritped Generic class
 - Updated dev dependencies to install `types-dataclasses` for Python 3.6 (to fix Annotations tests)
 - Updated `_decode_dataclass` to use `_isinstance_safe` instead of simple `isinstance`
 - Added TypeError handler for `_hasargs` function
