### PR TITLE
fix: prevent unwrapping union type with none value

### DIFF
--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -267,7 +267,7 @@ def _decode_generic(type_, value, infer_missing):
         if not hasattr(type_, "__args__"):
             # Any, just accept
             res = value
-        elif _is_optional(type_) and len(type_.__args__) == 2:  # Optional
+        elif _is_optional(type_) and len(type_.__args__) == 2 and type_.__args__[1] != type(None):
             type_arg = type_.__args__[0]
             if is_dataclass(type_arg) or is_dataclass(value):
                 res = _decode_dataclass(type_arg, value, infer_missing)


### PR DESCRIPTION
## Motivation

With a field like so, the library attempted to incorrectly decode the type even if there was a None value.

```
    control_data: Optional[Dict[str, Dict[str, Any]]] = None,
```

Resulting in the trace when `control_data=None`.

```
  File ".../python3.8/site-packages/dataclasses_json/core.py", line 258, in _decode_generic
    ks = _decode_dict_keys(k_type, value.keys(), infer_missing)
AttributeError: 'list' object has no attribute 'keys'
```

This small fix simply checks if the value of an Optional is None.
If so, it returns it.