### PR TITLE
Explicitly allow dataclasses_json.cfg.config() argument letter_case to accept LetterCase members

### DIFF
--- a/dataclasses_json/__init__.py
+++ b/dataclasses_json/__init__.py
@@ -1,8 +1,8 @@
 # flake8: noqa
 from dataclasses_json.api import (DataClassJsonMixin,
-                                  LetterCase,
                                   dataclass_json)
-from dataclasses_json.cfg import config, global_config, Exclude
+from dataclasses_json.cfg import (config, global_config,
+                                  Exclude, LetterCase)
 from dataclasses_json.undefined import CatchAll, Undefined
 
 __all__ = ['DataClassJsonMixin', 'LetterCase', 'dataclass_json',

--- a/dataclasses_json/api.py
+++ b/dataclasses_json/api.py
@@ -3,7 +3,7 @@ import json
 from typing import (Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar,
                     Union)
 
-from dataclasses_json.cfg import config, LetterCase
+from dataclasses_json.cfg import config, LetterCase  # noqa: F401
 from dataclasses_json.core import (Json, _ExtendedEncoder, _asdict,
                                    _decode_dataclass)
 from dataclasses_json.mm import (JsonData, SchemaType, build_schema)
@@ -15,7 +15,6 @@ A = TypeVar('A', bound="DataClassJsonMixin")
 B = TypeVar('B')
 C = TypeVar('C')
 Fields = List[Tuple[str, Any]]
-
 
 
 class DataClassJsonMixin(abc.ABC):

--- a/dataclasses_json/api.py
+++ b/dataclasses_json/api.py
@@ -1,12 +1,9 @@
 import abc
 import json
-from enum import Enum
 from typing import (Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar,
                     Union)
 
-from dataclasses_json.stringcase import (camelcase, pascalcase, snakecase,
-                                         spinalcase)  # type: ignore
-from dataclasses_json.cfg import config
+from dataclasses_json.cfg import config, LetterCase
 from dataclasses_json.core import (Json, _ExtendedEncoder, _asdict,
                                    _decode_dataclass)
 from dataclasses_json.mm import (JsonData, SchemaType, build_schema)
@@ -19,12 +16,6 @@ B = TypeVar('B')
 C = TypeVar('C')
 Fields = List[Tuple[str, Any]]
 
-
-class LetterCase(Enum):
-    CAMEL = camelcase
-    KEBAB = spinalcase
-    SNAKE = snakecase
-    PASCAL = pascalcase
 
 
 class DataClassJsonMixin(abc.ABC):

--- a/dataclasses_json/cfg.py
+++ b/dataclasses_json/cfg.py
@@ -1,8 +1,11 @@
 import functools
+from enum import Enum
 from typing import Callable, Dict, Optional, TypeVar, Union
 
 from marshmallow.fields import Field as MarshmallowField
 
+from dataclasses_json.stringcase import (camelcase, pascalcase, snakecase,
+                                         spinalcase)  # type: ignore
 from dataclasses_json.undefined import Undefined, UndefinedParameterError
 
 T = TypeVar("T")
@@ -40,6 +43,12 @@ class _GlobalConfig:
 
 global_config = _GlobalConfig()
 
+class LetterCase(Enum):
+    CAMEL = camelcase
+    KEBAB = spinalcase
+    SNAKE = snakecase
+    PASCAL = pascalcase
+
 
 def config(metadata: dict = None, *,
            # TODO: these can be typed more precisely
@@ -47,7 +56,7 @@ def config(metadata: dict = None, *,
            encoder: Callable = None,
            decoder: Callable = None,
            mm_field: MarshmallowField = None,
-           letter_case: Callable[[str], str] = None,
+           letter_case: Union[Callable[[str], str], LetterCase] = None,
            undefined: Optional[Union[str, Undefined]] = None,
            field_name: str = None,
            exclude: Optional[Callable[[str, T], bool]] = None,

--- a/dataclasses_json/cfg.py
+++ b/dataclasses_json/cfg.py
@@ -57,10 +57,10 @@ def config(metadata: dict = None, *,
            encoder: Callable = None,
            decoder: Callable = None,
            mm_field: MarshmallowField = None,
-           letter_case: Union[Callable[[str], str], LetterCase] = None,
+           letter_case: Union[Callable[[str], str], LetterCase, None] = None,
            undefined: Optional[Union[str, Undefined]] = None,
            field_name: str = None,
-           exclude: Optional[Callable[[str, T], bool]] = None,
+           exclude: Union[Callable[[str, T], bool], Exclude, None] = None,
            ) -> Dict[str, dict]:
     if metadata is None:
         metadata = {}

--- a/dataclasses_json/cfg.py
+++ b/dataclasses_json/cfg.py
@@ -43,6 +43,7 @@ class _GlobalConfig:
 
 global_config = _GlobalConfig()
 
+
 class LetterCase(Enum):
     CAMEL = camelcase
     KEBAB = spinalcase

--- a/dataclasses_json/cfg.py
+++ b/dataclasses_json/cfg.py
@@ -78,11 +78,11 @@ def config(metadata: dict = None, *,
 
     if field_name is not None:
         if letter_case is not None:
-            @functools.wraps(letter_case)
+            @functools.wraps(letter_case)  # type:ignore
             def override(_, _letter_case=letter_case, _field_name=field_name):
                 return _letter_case(_field_name)
         else:
-            def override(_, _field_name=field_name):
+            def override(_, _field_name=field_name):  # type:ignore
                 return _field_name
         letter_case = override
 


### PR DESCRIPTION
Closes #286

### Changes:
 - `LetterCase` class moved from `.api` to `.cfg` (imported in `.api` for backwards-compatibilty
 - `dataclasses_json.cfg.config()` now explicitly accepts either `Callable[...]` or `LetterCase` for parameter `letter_case`
 - `dataclasses_json.cfg.config()` now explicitly accepts either `Callable[...]` or `Exclude` for parameter `exclude`
