### PR TITLE
Annotations test: Add `clean_exit=True` for `mypy_main()`

### DIFF
--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -105,7 +105,7 @@ class TestAnnotations:
         try:
             # mypy.main uses sys.stdout for printing
             # We override it to catch error messages
-            mypy_main(None, text_io, text_io, [__file__])
+            mypy_main(None, text_io, text_io, [__file__], clean_exit=True)
         except SystemExit:
             # mypy.main could return errors found inside other files.
             # filter_errors() will filter out all errors outside this file.


### PR DESCRIPTION
Closes #335

MyPy added a parameter `clean_exit` which must be set to `True` in order to intercept `SystemExit`.
That lead to the pytest process exiting after executing the first ever test (because annotations are alphabetically first).
