### PR TITLE
#341: Fixes for type-parameters without arguments

### DIFF
--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -329,8 +329,10 @@ def _decode_dict_keys(key_type, xs, infer_missing):
     decode_function = key_type
     # handle NoneType keys... it's weird to type a Dict as NoneType keys
     # but it's valid...
-    # Issue #341 and MR #346: This is a special case for Python 3.7 and Python 3.8.
-    # By some reason, "unbound" dicts are counted as having key type parameter to be TypeVar('KT')
+    # Issue #341 and PR #346:
+    #   This is a special case for Python 3.7 and Python 3.8.
+    #   By some reason, "unbound" dicts are counted
+    #   as having key type parameter to be TypeVar('KT')
     if key_type is None or key_type == Any or isinstance(key_type, TypeVar):
         decode_function = key_type = (lambda x: x)
     # handle a nested python dict that has tuples for keys. E.g. for

--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -329,6 +329,8 @@ def _decode_dict_keys(key_type, xs, infer_missing):
     decode_function = key_type
     # handle NoneType keys... it's weird to type a Dict as NoneType keys
     # but it's valid...
+    # Issue #341 and MR #346: This is a special case for Python 3.7 and Python 3.8.
+    # By some reason, "unbound" dicts are counted as having key type parameter to be TypeVar('KT')
     if key_type is None or key_type == Any or isinstance(key_type, TypeVar):
         decode_function = key_type = (lambda x: x)
     # handle a nested python dict that has tuples for keys. E.g. for

--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -108,9 +108,9 @@ _NO_ARGS = _NoArgs()
 def _extract_args(tp: Type, default: Tuple[Type, ...] = _NO_ARGS) -> \
         Union[Tuple[Type, ...], _NoArgs]:
     if hasattr(tp, '__args__'):
-        return tp.__args__
-    else:
-        return default
+        if tp.__args__ is not None:
+            return tp.__args__
+    return default
 
 
 def _extract_type_parameter(tp: Type, index: int) -> Union[Type, _NoArgs]:

--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -11,7 +11,8 @@ from dataclasses import (MISSING,
 from datetime import datetime, timezone
 from decimal import Decimal
 from enum import Enum
-from typing import Any, Collection, Mapping, Union, get_type_hints, Tuple, Type
+from typing import (Any, Collection, Mapping, Union, get_type_hints,
+                    Tuple, Type, TypeVar)
 from uuid import UUID
 
 from typing_inspect import is_union_type  # type: ignore
@@ -328,7 +329,7 @@ def _decode_dict_keys(key_type, xs, infer_missing):
     decode_function = key_type
     # handle NoneType keys... it's weird to type a Dict as NoneType keys
     # but it's valid...
-    if key_type is None or key_type == Any:
+    if key_type is None or key_type == Any or isinstance(key_type, TypeVar):
         decode_function = key_type = (lambda x: x)
     # handle a nested python dict that has tuples for keys. E.g. for
     # Dict[Tuple[int], int], key_type will be typing.Tuple[int], but

--- a/dataclasses_json/utils.py
+++ b/dataclasses_json/utils.py
@@ -1,7 +1,8 @@
 import inspect
 import sys
 from datetime import datetime, timezone
-from typing import Collection, Mapping, Optional, TypeVar, Any
+from typing import (Collection, Mapping, Optional, TypeVar, Any, Type, Tuple,
+                    Union)
 
 
 def _get_type_cons(type_):
@@ -63,6 +64,42 @@ def _hasargs(type_, *args):
             raise
     else:
         return res
+
+
+class _NoArgs(object):
+    def __bool__(self):
+        return False
+
+    def __len__(self):
+        return 0
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        raise StopIteration
+
+
+_NO_ARGS = _NoArgs()
+
+
+def _get_type_args(tp: Type, default: Tuple[Type, ...] = _NO_ARGS) -> \
+        Union[Tuple[Type, ...], _NoArgs]:
+    if hasattr(tp, '__args__'):
+        if tp.__args__ is not None:
+            return tp.__args__
+    return default
+
+
+def _get_type_arg_param(tp: Type, index: int) -> Union[Type, _NoArgs]:
+    _args = _get_type_args(tp)
+    if _args is not _NO_ARGS:
+        try:
+            return _args[index]
+        except (TypeError, IndexError, NotImplementedError):
+            pass
+
+    return _NO_ARGS
 
 
 def _isinstance_safe(o, t):

--- a/dataclasses_json/utils.py
+++ b/dataclasses_json/utils.py
@@ -26,21 +26,28 @@ def _get_type_cons(type_):
     return cons
 
 
+_NO_TYPE_ORIGIN = object()
+
+
 def _get_type_origin(type_):
     """Some spaghetti logic to accommodate differences between 3.6 and 3.7 in
     the typing api"""
     try:
         origin = type_.__origin__
     except AttributeError:
-        if sys.version_info.minor == 6:
-            try:
-                origin = type_.__extra__
-            except AttributeError:
-                origin = type_
-            else:
-                origin = type_ if origin is None else origin
-        else:
+        # Issue #341 and PR #346:
+        # For some cases, the type_.__origin__ exists but is set to None
+        origin = _NO_TYPE_ORIGIN
+
+    if sys.version_info.minor == 6:
+        try:
+            origin = type_.__extra__
+        except AttributeError:
             origin = type_
+        else:
+            origin = type_ if origin in (None, _NO_TYPE_ORIGIN) else origin
+    elif origin is _NO_TYPE_ORIGIN:
+        origin = type_
     return origin
 
 

--- a/tests/entities.py
+++ b/tests/entities.py
@@ -1,4 +1,6 @@
+from collections import deque
 from dataclasses import dataclass, field
+from datetime import datetime
 from decimal import Decimal
 from typing import (Collection,
                     Deque,
@@ -16,11 +18,8 @@ from uuid import UUID
 
 from marshmallow import fields
 
-import dataclasses_json
-from datetime import datetime
-
-from dataclasses_json.cfg import config
 from dataclasses_json import (DataClassJsonMixin, LetterCase, dataclass_json)
+from dataclasses_json.cfg import config
 
 A = TypeVar('A')
 UUIDWrapper = NewType('UUIDWrapper', UUID)
@@ -48,6 +47,16 @@ class DataClassWithList(DataClassJsonMixin):
 
 
 @dataclass(frozen=True)
+class DataClassWithListBuiltin(DataClassJsonMixin):
+    xs: list
+
+
+@dataclass(frozen=True)
+class DataClassWithListGeneric(DataClassJsonMixin):
+    xs: List
+
+
+@dataclass(frozen=True)
 class DataClassWithListDefaultFactory(DataClassJsonMixin):
     xs: List[int] = field(default_factory=list)
 
@@ -60,6 +69,16 @@ class DataClassWithListStr(DataClassJsonMixin):
 @dataclass(frozen=True)
 class DataClassWithDict(DataClassJsonMixin):
     kvs: Dict[str, str]
+
+
+@dataclass(frozen=True)
+class DataClassWithDictBuiltin(DataClassJsonMixin):
+    kvs: Dict
+
+
+@dataclass(frozen=True)
+class DataClassWithDictGeneric(DataClassJsonMixin):
+    kvs: Dict
 
 
 @dataclass(frozen=True)
@@ -78,8 +97,28 @@ class DataClassWithSet(DataClassJsonMixin):
 
 
 @dataclass(frozen=True)
+class DataClassWithSetBuiltin(DataClassJsonMixin):
+    xs: set
+
+
+@dataclass(frozen=True)
+class DataClassWithSetGeneric(DataClassJsonMixin):
+    xs: Set
+
+
+@dataclass(frozen=True)
 class DataClassWithTuple(DataClassJsonMixin):
     xs: Tuple[int]
+
+
+@dataclass(frozen=True)
+class DataClassWithTupleBuiltin(DataClassJsonMixin):
+    xs: tuple
+
+
+@dataclass(frozen=True)
+class DataClassWithTupleGeneric(DataClassJsonMixin):
+    xs: Tuple
 
 
 @dataclass(frozen=True)
@@ -88,13 +127,38 @@ class DataClassWithFrozenSet(DataClassJsonMixin):
 
 
 @dataclass(frozen=True)
+class DataClassWithFrozenSetBuiltin(DataClassJsonMixin):
+    xs: frozenset
+
+
+@dataclass(frozen=True)
+class DataClassWithFrozenSetGeneric(DataClassJsonMixin):
+    xs: FrozenSet
+
+
+@dataclass(frozen=True)
 class DataClassWithDeque(DataClassJsonMixin):
+    xs: Deque[int]
+
+
+@dataclass(frozen=True)
+class DataClassWithDequeCollections(DataClassJsonMixin):
+    xs: deque
+
+
+@dataclass(frozen=True)
+class DataClassWithDequeGeneric(DataClassJsonMixin):
     xs: Deque[int]
 
 
 @dataclass(frozen=True)
 class DataClassWithOptional(DataClassJsonMixin):
     x: Optional[int]
+
+
+@dataclass(frozen=True)
+class DataClassWithOptionalGeneric(DataClassJsonMixin):
+    x: Optional
 
 
 @dataclass

--- a/tests/entities.py
+++ b/tests/entities.py
@@ -52,7 +52,7 @@ class DataClassWithListBuiltin(DataClassJsonMixin):
 
 
 @dataclass(frozen=True)
-class DataClassWithListGeneric(DataClassJsonMixin):
+class DataClassWithListUnbound(DataClassJsonMixin):
     xs: List
 
 
@@ -77,7 +77,7 @@ class DataClassWithDictBuiltin(DataClassJsonMixin):
 
 
 @dataclass(frozen=True)
-class DataClassWithDictGeneric(DataClassJsonMixin):
+class DataClassWithDictUnbound(DataClassJsonMixin):
     kvs: Dict
 
 
@@ -102,7 +102,7 @@ class DataClassWithSetBuiltin(DataClassJsonMixin):
 
 
 @dataclass(frozen=True)
-class DataClassWithSetGeneric(DataClassJsonMixin):
+class DataClassWithSetUnbound(DataClassJsonMixin):
     xs: Set
 
 
@@ -117,7 +117,7 @@ class DataClassWithTupleBuiltin(DataClassJsonMixin):
 
 
 @dataclass(frozen=True)
-class DataClassWithTupleGeneric(DataClassJsonMixin):
+class DataClassWithTupleUnbound(DataClassJsonMixin):
     xs: Tuple
 
 
@@ -132,7 +132,7 @@ class DataClassWithFrozenSetBuiltin(DataClassJsonMixin):
 
 
 @dataclass(frozen=True)
-class DataClassWithFrozenSetGeneric(DataClassJsonMixin):
+class DataClassWithFrozenSetUnbound(DataClassJsonMixin):
     xs: FrozenSet
 
 
@@ -147,7 +147,7 @@ class DataClassWithDequeCollections(DataClassJsonMixin):
 
 
 @dataclass(frozen=True)
-class DataClassWithDequeGeneric(DataClassJsonMixin):
+class DataClassWithDequeUnbound(DataClassJsonMixin):
     xs: Deque[int]
 
 
@@ -157,7 +157,7 @@ class DataClassWithOptional(DataClassJsonMixin):
 
 
 @dataclass(frozen=True)
-class DataClassWithOptionalGeneric(DataClassJsonMixin):
+class DataClassWithOptionalUnbound(DataClassJsonMixin):
     x: Optional
 
 

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -4,10 +4,21 @@ from tests.entities import (DataClassIntImmutableDefault,
                             DataClassMutableDefaultDict,
                             DataClassMutableDefaultList, DataClassWithDeque,
                             DataClassWithDict, DataClassWithDictInt,
+                            DataClassWithDictGeneric,
                             DataClassWithFrozenSet, DataClassWithList,
-                            DataClassWithListStr, DataClassWithMyCollection,
+                            DataClassWithListGeneric, DataClassWithListStr, DataClassWithMyCollection,
                             DataClassWithOptional, DataClassWithOptionalStr,
-                            DataClassWithSet, DataClassWithTuple,
+                            DataClassWithSet, DataClassWithSetGeneric,
+                            DataClassWithOptionalGeneric,
+                            DataClassWithSetBuiltin,
+                            DataClassWithDictBuiltin,
+                            DataClassWithListBuiltin,
+                            DataClassWithTupleBuiltin,
+                            DataClassWithFrozenSetBuiltin,
+                            DataClassWithDequeGeneric,
+                            DataClassWithFrozenSetGeneric,
+                            DataClassWithDequeCollections,
+                            DataClassWithTuple, DataClassWithTupleGeneric,
                             DataClassWithUnionIntNone, MyCollection)
 
 
@@ -15,11 +26,23 @@ class TestEncoder:
     def test_list(self):
         assert DataClassWithList([1]).to_json() == '{"xs": [1]}'
 
+    def test_list_generic(self):
+        assert DataClassWithListGeneric([1]).to_json() == '{"xs": [1]}'
+
+    def test_list_builtin(self):
+        assert DataClassWithListBuiltin([1]).to_json() == '{"xs": [1]}'
+
     def test_list_str(self):
         assert DataClassWithListStr(['1']).to_json() == '{"xs": ["1"]}'
 
     def test_dict(self):
         assert DataClassWithDict({'1': 'a'}).to_json() == '{"kvs": {"1": "a"}}'
+
+    def test_dict_generic(self):
+        assert DataClassWithDictGeneric({'1': 'a'}).to_json() == '{"kvs": {"1": "a"}}'
+
+    def test_dict_builtin(self):
+        assert DataClassWithDictBuiltin({'1': 'a'}).to_json() == '{"kvs": {"1": "a"}}'
 
     def test_dict_int(self):
         assert DataClassWithDictInt({1: 'a'}).to_json() == '{"kvs": {"1": "a"}}'
@@ -27,18 +50,45 @@ class TestEncoder:
     def test_set(self):
         assert DataClassWithSet({1}).to_json() == '{"xs": [1]}'
 
+    def test_set_generic(self):
+        assert DataClassWithSetGeneric({1}).to_json() == '{"xs": [1]}'
+
+    def test_set_builtin(self):
+        assert DataClassWithSetBuiltin({1}).to_json() == '{"xs": [1]}'
+
     def test_tuple(self):
         assert DataClassWithTuple((1,)).to_json() == '{"xs": [1]}'
+
+    def test_tuple_generic(self):
+        assert DataClassWithTupleGeneric((1,)).to_json() == '{"xs": [1]}'
+
+    def test_tuple_builtin(self):
+        assert DataClassWithTupleBuiltin((1,)).to_json() == '{"xs": [1]}'
 
     def test_frozenset(self):
         assert DataClassWithFrozenSet(frozenset([1])).to_json() == '{"xs": [1]}'
 
+    def test_frozenset_generic(self):
+        assert DataClassWithFrozenSetGeneric(frozenset([1])).to_json() == '{"xs": [1]}'
+
+    def test_frozenset_builtin(self):
+        assert DataClassWithFrozenSetBuiltin(frozenset([1])).to_json() == '{"xs": [1]}'
+
     def test_deque(self):
         assert DataClassWithDeque(deque([1])).to_json() == '{"xs": [1]}'
+
+    def test_deque_generic(self):
+        assert DataClassWithDequeGeneric(deque([1])).to_json() == '{"xs": [1]}'
+
+    def test_deque_builtin(self):
+        assert DataClassWithDequeCollections(deque([1])).to_json() == '{"xs": [1]}'
 
     def test_optional(self):
         assert DataClassWithOptional(1).to_json() == '{"x": 1}'
         assert DataClassWithOptional(None).to_json() == '{"x": null}'
+
+    def test_optional_generic(self):
+        assert DataClassWithOptionalGeneric(1).to_json() == '{"x": 1}'
 
     def test_optional_str(self):
         assert DataClassWithOptionalStr('1').to_json() == '{"x": "1"}'
@@ -68,6 +118,14 @@ class TestDecoder:
         assert (DataClassWithList.from_json('{"xs": [1]}') ==
                 DataClassWithList([1]))
 
+    def test_list_generic(self):
+        assert (DataClassWithListGeneric.from_json('{"xs": [1]}') ==
+                DataClassWithListGeneric([1]))
+
+    def test_list_builtin(self):
+        assert (DataClassWithListBuiltin.from_json('{"xs": [1]}') ==
+                DataClassWithListBuiltin([1]))
+
     def test_list_str(self):
         assert (DataClassWithListStr.from_json('{"xs": ["1"]}') ==
                 DataClassWithListStr(["1"]))
@@ -75,6 +133,14 @@ class TestDecoder:
     def test_dict(self):
         assert (DataClassWithDict.from_json('{"kvs": {"1": "a"}}') ==
                 DataClassWithDict({'1': 'a'}))
+
+    def test_dict_generic(self):
+        assert (DataClassWithDictGeneric.from_json('{"kvs": {"1": "a"}}') ==
+                DataClassWithDictGeneric({'1': 'a'}))
+
+    def test_dict_builtin(self):
+        assert (DataClassWithDictBuiltin.from_json('{"kvs": {"1": "a"}}') ==
+                DataClassWithDictBuiltin({'1': 'a'}))
 
     def test_dict_int(self):
         assert (DataClassWithDictInt.from_json('{"kvs": {"1": "a"}}') ==
@@ -84,23 +150,61 @@ class TestDecoder:
         assert (DataClassWithSet.from_json('{"xs": [1]}') ==
                 DataClassWithSet({1}))
 
+    def test_set_generic(self):
+        assert (DataClassWithSetGeneric.from_json('{"xs": [1]}') ==
+                DataClassWithSetGeneric({1}))
+
+    def test_set_builtin(self):
+        assert (DataClassWithSetBuiltin.from_json('{"xs": [1]}') ==
+                DataClassWithSetBuiltin({1}))
+
     def test_tuple(self):
         assert (DataClassWithTuple.from_json('{"xs": [1]}') ==
                 DataClassWithTuple((1,)))
+
+    def test_tuple_generic(self):
+        assert (DataClassWithTupleGeneric.from_json('{"xs": [1]}') ==
+                DataClassWithTupleGeneric((1,)))
+
+    def test_tuple_builtin(self):
+        assert (DataClassWithTupleBuiltin.from_json('{"xs": [1]}') ==
+                DataClassWithTupleBuiltin((1,)))
 
     def test_frozenset(self):
         assert (DataClassWithFrozenSet.from_json('{"xs": [1]}') ==
                 DataClassWithFrozenSet(frozenset([1])))
 
+    def test_frozenset_generic(self):
+        assert (DataClassWithFrozenSetGeneric.from_json('{"xs": [1]}') ==
+                DataClassWithFrozenSetGeneric(frozenset([1])))
+
+    def test_frozenset_builtin(self):
+        assert (DataClassWithFrozenSetBuiltin.from_json('{"xs": [1]}') ==
+                DataClassWithFrozenSetBuiltin(frozenset([1])))
+
     def test_deque(self):
         assert (DataClassWithDeque.from_json('{"xs": [1]}') ==
                 DataClassWithDeque(deque([1])))
+
+    def test_deque_generic(self):
+        assert (DataClassWithDequeGeneric.from_json('{"xs": [1]}') ==
+                DataClassWithDequeGeneric(deque([1])))
+
+    def test_deque_collections(self):
+        assert (DataClassWithDequeCollections.from_json('{"xs": [1]}') ==
+                DataClassWithDequeCollections(deque([1])))
 
     def test_optional(self):
         assert (DataClassWithOptional.from_json('{"x": 1}') ==
                 DataClassWithOptional(1))
         assert (DataClassWithOptional.from_json('{"x": null}') ==
                 DataClassWithOptional(None))
+
+    def test_optional_generic(self):
+        assert (DataClassWithOptionalGeneric.from_json('{"x": 1}') ==
+                DataClassWithOptionalGeneric(1))
+        assert (DataClassWithOptionalGeneric.from_json('{"x": null}') ==
+                DataClassWithOptionalGeneric(None))
 
     def test_optional_str(self):
         assert (DataClassWithOptionalStr.from_json('{"x": "1"}') ==

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -4,21 +4,21 @@ from tests.entities import (DataClassIntImmutableDefault,
                             DataClassMutableDefaultDict,
                             DataClassMutableDefaultList, DataClassWithDeque,
                             DataClassWithDict, DataClassWithDictInt,
-                            DataClassWithDictGeneric,
+                            DataClassWithDictUnbound,
                             DataClassWithFrozenSet, DataClassWithList,
-                            DataClassWithListGeneric, DataClassWithListStr, DataClassWithMyCollection,
+                            DataClassWithListUnbound, DataClassWithListStr, DataClassWithMyCollection,
                             DataClassWithOptional, DataClassWithOptionalStr,
-                            DataClassWithSet, DataClassWithSetGeneric,
-                            DataClassWithOptionalGeneric,
+                            DataClassWithSet, DataClassWithSetUnbound,
+                            DataClassWithOptionalUnbound,
                             DataClassWithSetBuiltin,
                             DataClassWithDictBuiltin,
                             DataClassWithListBuiltin,
                             DataClassWithTupleBuiltin,
                             DataClassWithFrozenSetBuiltin,
-                            DataClassWithDequeGeneric,
-                            DataClassWithFrozenSetGeneric,
+                            DataClassWithDequeUnbound,
+                            DataClassWithFrozenSetUnbound,
                             DataClassWithDequeCollections,
-                            DataClassWithTuple, DataClassWithTupleGeneric,
+                            DataClassWithTuple, DataClassWithTupleUnbound,
                             DataClassWithUnionIntNone, MyCollection)
 
 
@@ -26,8 +26,8 @@ class TestEncoder:
     def test_list(self):
         assert DataClassWithList([1]).to_json() == '{"xs": [1]}'
 
-    def test_list_generic(self):
-        assert DataClassWithListGeneric([1]).to_json() == '{"xs": [1]}'
+    def test_list_unbound(self):
+        assert DataClassWithListUnbound([1]).to_json() == '{"xs": [1]}'
 
     def test_list_builtin(self):
         assert DataClassWithListBuiltin([1]).to_json() == '{"xs": [1]}'
@@ -38,8 +38,8 @@ class TestEncoder:
     def test_dict(self):
         assert DataClassWithDict({'1': 'a'}).to_json() == '{"kvs": {"1": "a"}}'
 
-    def test_dict_generic(self):
-        assert DataClassWithDictGeneric({'1': 'a'}).to_json() == '{"kvs": {"1": "a"}}'
+    def test_dict_unbound(self):
+        assert DataClassWithDictUnbound({'1': 'a'}).to_json() == '{"kvs": {"1": "a"}}'
 
     def test_dict_builtin(self):
         assert DataClassWithDictBuiltin({'1': 'a'}).to_json() == '{"kvs": {"1": "a"}}'
@@ -50,8 +50,8 @@ class TestEncoder:
     def test_set(self):
         assert DataClassWithSet({1}).to_json() == '{"xs": [1]}'
 
-    def test_set_generic(self):
-        assert DataClassWithSetGeneric({1}).to_json() == '{"xs": [1]}'
+    def test_set_unbound(self):
+        assert DataClassWithSetUnbound({1}).to_json() == '{"xs": [1]}'
 
     def test_set_builtin(self):
         assert DataClassWithSetBuiltin({1}).to_json() == '{"xs": [1]}'
@@ -59,8 +59,8 @@ class TestEncoder:
     def test_tuple(self):
         assert DataClassWithTuple((1,)).to_json() == '{"xs": [1]}'
 
-    def test_tuple_generic(self):
-        assert DataClassWithTupleGeneric((1,)).to_json() == '{"xs": [1]}'
+    def test_tuple_unbound(self):
+        assert DataClassWithTupleUnbound((1,)).to_json() == '{"xs": [1]}'
 
     def test_tuple_builtin(self):
         assert DataClassWithTupleBuiltin((1,)).to_json() == '{"xs": [1]}'
@@ -68,8 +68,8 @@ class TestEncoder:
     def test_frozenset(self):
         assert DataClassWithFrozenSet(frozenset([1])).to_json() == '{"xs": [1]}'
 
-    def test_frozenset_generic(self):
-        assert DataClassWithFrozenSetGeneric(frozenset([1])).to_json() == '{"xs": [1]}'
+    def test_frozenset_unbound(self):
+        assert DataClassWithFrozenSetUnbound(frozenset([1])).to_json() == '{"xs": [1]}'
 
     def test_frozenset_builtin(self):
         assert DataClassWithFrozenSetBuiltin(frozenset([1])).to_json() == '{"xs": [1]}'
@@ -77,8 +77,8 @@ class TestEncoder:
     def test_deque(self):
         assert DataClassWithDeque(deque([1])).to_json() == '{"xs": [1]}'
 
-    def test_deque_generic(self):
-        assert DataClassWithDequeGeneric(deque([1])).to_json() == '{"xs": [1]}'
+    def test_deque_unbound(self):
+        assert DataClassWithDequeUnbound(deque([1])).to_json() == '{"xs": [1]}'
 
     def test_deque_builtin(self):
         assert DataClassWithDequeCollections(deque([1])).to_json() == '{"xs": [1]}'
@@ -87,8 +87,8 @@ class TestEncoder:
         assert DataClassWithOptional(1).to_json() == '{"x": 1}'
         assert DataClassWithOptional(None).to_json() == '{"x": null}'
 
-    def test_optional_generic(self):
-        assert DataClassWithOptionalGeneric(1).to_json() == '{"x": 1}'
+    def test_optional_unbound(self):
+        assert DataClassWithOptionalUnbound(1).to_json() == '{"x": 1}'
 
     def test_optional_str(self):
         assert DataClassWithOptionalStr('1').to_json() == '{"x": "1"}'
@@ -118,9 +118,9 @@ class TestDecoder:
         assert (DataClassWithList.from_json('{"xs": [1]}') ==
                 DataClassWithList([1]))
 
-    def test_list_generic(self):
-        assert (DataClassWithListGeneric.from_json('{"xs": [1]}') ==
-                DataClassWithListGeneric([1]))
+    def test_list_unbound(self):
+        assert (DataClassWithListUnbound.from_json('{"xs": [1]}') ==
+                DataClassWithListUnbound([1]))
 
     def test_list_builtin(self):
         assert (DataClassWithListBuiltin.from_json('{"xs": [1]}') ==
@@ -134,9 +134,9 @@ class TestDecoder:
         assert (DataClassWithDict.from_json('{"kvs": {"1": "a"}}') ==
                 DataClassWithDict({'1': 'a'}))
 
-    def test_dict_generic(self):
-        assert (DataClassWithDictGeneric.from_json('{"kvs": {"1": "a"}}') ==
-                DataClassWithDictGeneric({'1': 'a'}))
+    def test_dict_unbound(self):
+        assert (DataClassWithDictUnbound.from_json('{"kvs": {"1": "a"}}') ==
+                DataClassWithDictUnbound({'1': 'a'}))
 
     def test_dict_builtin(self):
         assert (DataClassWithDictBuiltin.from_json('{"kvs": {"1": "a"}}') ==
@@ -150,9 +150,9 @@ class TestDecoder:
         assert (DataClassWithSet.from_json('{"xs": [1]}') ==
                 DataClassWithSet({1}))
 
-    def test_set_generic(self):
-        assert (DataClassWithSetGeneric.from_json('{"xs": [1]}') ==
-                DataClassWithSetGeneric({1}))
+    def test_set_unbound(self):
+        assert (DataClassWithSetUnbound.from_json('{"xs": [1]}') ==
+                DataClassWithSetUnbound({1}))
 
     def test_set_builtin(self):
         assert (DataClassWithSetBuiltin.from_json('{"xs": [1]}') ==
@@ -162,9 +162,9 @@ class TestDecoder:
         assert (DataClassWithTuple.from_json('{"xs": [1]}') ==
                 DataClassWithTuple((1,)))
 
-    def test_tuple_generic(self):
-        assert (DataClassWithTupleGeneric.from_json('{"xs": [1]}') ==
-                DataClassWithTupleGeneric((1,)))
+    def test_tuple_unbound(self):
+        assert (DataClassWithTupleUnbound.from_json('{"xs": [1]}') ==
+                DataClassWithTupleUnbound((1,)))
 
     def test_tuple_builtin(self):
         assert (DataClassWithTupleBuiltin.from_json('{"xs": [1]}') ==
@@ -174,9 +174,9 @@ class TestDecoder:
         assert (DataClassWithFrozenSet.from_json('{"xs": [1]}') ==
                 DataClassWithFrozenSet(frozenset([1])))
 
-    def test_frozenset_generic(self):
-        assert (DataClassWithFrozenSetGeneric.from_json('{"xs": [1]}') ==
-                DataClassWithFrozenSetGeneric(frozenset([1])))
+    def test_frozenset_unbound(self):
+        assert (DataClassWithFrozenSetUnbound.from_json('{"xs": [1]}') ==
+                DataClassWithFrozenSetUnbound(frozenset([1])))
 
     def test_frozenset_builtin(self):
         assert (DataClassWithFrozenSetBuiltin.from_json('{"xs": [1]}') ==
@@ -186,9 +186,9 @@ class TestDecoder:
         assert (DataClassWithDeque.from_json('{"xs": [1]}') ==
                 DataClassWithDeque(deque([1])))
 
-    def test_deque_generic(self):
-        assert (DataClassWithDequeGeneric.from_json('{"xs": [1]}') ==
-                DataClassWithDequeGeneric(deque([1])))
+    def test_deque_unbound(self):
+        assert (DataClassWithDequeUnbound.from_json('{"xs": [1]}') ==
+                DataClassWithDequeUnbound(deque([1])))
 
     def test_deque_collections(self):
         assert (DataClassWithDequeCollections.from_json('{"xs": [1]}') ==
@@ -200,11 +200,11 @@ class TestDecoder:
         assert (DataClassWithOptional.from_json('{"x": null}') ==
                 DataClassWithOptional(None))
 
-    def test_optional_generic(self):
-        assert (DataClassWithOptionalGeneric.from_json('{"x": 1}') ==
-                DataClassWithOptionalGeneric(1))
-        assert (DataClassWithOptionalGeneric.from_json('{"x": null}') ==
-                DataClassWithOptionalGeneric(None))
+    def test_optional_unbound(self):
+        assert (DataClassWithOptionalUnbound.from_json('{"x": 1}') ==
+                DataClassWithOptionalUnbound(1))
+        assert (DataClassWithOptionalUnbound.from_json('{"x": null}') ==
+                DataClassWithOptionalUnbound(None))
 
     def test_optional_str(self):
         assert (DataClassWithOptionalStr.from_json('{"x": "1"}') ==

--- a/tests/test_unsupported_generics.py
+++ b/tests/test_unsupported_generics.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from typing import TypeVar, Generic
+
 from dataclasses_json import DataClassJsonMixin
 
 
@@ -9,11 +10,11 @@ class ContainerCls(Generic[T]):
     required: bool
 
 @dataclass
-class DataClassWithUnsupscriptedGeneric(DataClassJsonMixin):
+class DataClassWithUnsubscriptedGeneric(DataClassJsonMixin):
     a: ContainerCls
 
 @dataclass
-class DataClassWithSupscriptedGeneric(DataClassJsonMixin):
+class DataClassWithSubscriptedGeneric(DataClassJsonMixin):
     a: ContainerCls[int]
 
 @dataclass
@@ -22,22 +23,22 @@ class DataClassWithParameterizedGeneric(DataClassJsonMixin, Generic[T]):
 
 
 class TestUnsupportedGenerics:
-    def test_unsupscripted(self):
+    def test_unsubscripted(self):
         j = '{ "a": { "value": "test", "required": true } }'
-        dc = DataClassWithUnsupscriptedGeneric.from_json(j)
+        dc = DataClassWithUnsubscriptedGeneric.from_json(j)
         assert dc.a == dict(value='test', required=True)
     
-    def test_supscripted(self):
+    def test_subscripted(self):
         j = '{ "a": { "value": 5, "required": false } }'
-        dc = DataClassWithSupscriptedGeneric.from_json(j)
+        dc = DataClassWithSubscriptedGeneric.from_json(j)
         assert dc.a == dict(value=5, required=False)
     
-    def test_parameterized_unsupscripted(self):
+    def test_parameterized_unsubscripted(self):
         j = '{ "a": { "value": "test", "required": true } }'
         dc = DataClassWithParameterizedGeneric.from_json(j)
         assert dc.a == dict(value='test', required=True)
     
-    def test_parameterized_supscripted(self):
+    def test_parameterized_subscripted(self):
         j = '{ "a": { "value": "test", "required": true } }'
         dc = DataClassWithParameterizedGeneric[str].from_json(j)
         assert dc.a == dict(value='test', required=True)


### PR DESCRIPTION
Closes #341

### Changes:
 * Updated `tests.entities` and `tests.test_collections` to include alternative forms of the same collection types
   (like `builtins.list` ("builtin") and `typing.List` (~~"generic"~~ "unbound") in addition to the existing `typing.List[TypeA]`)
 * Added new internal helper class ~~`core._NoArgs`~~ `utils._NoArgs` and its singleton instance ~~`core._NO_ARGS`~~ `utils._NO_ARGS`
 * Added new methods ~~`core._extract_args()`~~ `utils._get_type_args()` and ~~`core._extract_type_parameter()`~~ `utils._get_type_arg_param()` which return either `tp.__args__` value or `_NO_ARGS` constant
 * All "unsafe" usages of `tp.__args__` replaced with the new methods
 * Added `TypeVar` special case check for `core._decode_dict_keys()`
   - *Note:* This is a special case for Python 3.7 and Python 3.8.
     By some reason, "unbound" dicts are counted as having key type parameter to be `TypeVar('KT')`
 * Added `tp.__origin__ == None` special case for `utils._get_type_origin()`
   - *Note:* This is a special case for Python 3.6 exclusively.
     By some reason, *some* "unbound" types (`typing.Set`, `typing.Tuple`, and `typing.FrozenSet`) are considered to have this field with `None` rather than generating an `AttributeError`
   - Same for `tp.__args__` and dicts

### Status
 * Without the fix, new tests fail on all versions of Python, but fail differently (see report in the comments of #341)
 * By now, there are no failures related to the missing `tp.__args__`:
   + [x] Python 3.6: ~~Decodes "unbound" (but not "builtin") sets, tuples, and frozensets as lists rather than required types~~
   + [x] Python 3.7-3.8: ~~Fails to decode "unbound" and "builtin" dicts by trying to instantiate uninstantiatable `typing.Dict`.~~
      Was actually caused by the strange structure of dict class nesting in specifically these Python versions, see note above
   + [x] No longer fails on Python 3.9+
   + [x] *(New)* Python 3.6: ~~Unable to decode "unbound" `typing.Dict` and `dict` keys on Python 3.6 exclusively~~
