### PR TITLE
Add support for encoding numpy integer and floating point types

### DIFF
--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -16,6 +16,12 @@ from uuid import UUID
 
 from typing_inspect import is_union_type  # type: ignore
 
+try:
+    import numpy as np
+    np_available = True
+except ImportError:
+    np_available = False
+
 from dataclasses_json import cfg
 from dataclasses_json.utils import (_get_type_cons, _get_type_origin,
                                     _handle_undefined_parameters_safe,
@@ -45,6 +51,10 @@ class _ExtendedEncoder(json.JSONEncoder):
             result = o.value
         elif _isinstance_safe(o, Decimal):
             result = str(o)
+        elif np_available and isinstance(o, np.integer):
+            result = int(o)
+        elif np_available and isinstance(o, np.floating):
+            result = float(o)
         else:
             result = json.JSONEncoder.default(self, o)
         return result

--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -51,10 +51,10 @@ class _ExtendedEncoder(json.JSONEncoder):
             result = o.value
         elif _isinstance_safe(o, Decimal):
             result = str(o)
-        elif np_available and _isinstance_safe(o, np.integer):
-            result = int(o)
-        elif np_available and _isinstance_safe(o, np.floating):
-            result = float(o)
+        elif np_available and np.isscalar(o):
+            result = o.item()
+        elif np_available and _isinstance_safe(o, np.ndarray):
+            result = o.tolist()
         else:
             result = json.JSONEncoder.default(self, o)
         return result

--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -51,9 +51,9 @@ class _ExtendedEncoder(json.JSONEncoder):
             result = o.value
         elif _isinstance_safe(o, Decimal):
             result = str(o)
-        elif np_available and isinstance(o, np.integer):
+        elif np_available and _isinstance_safe(o, np.integer):
             result = int(o)
-        elif np_available and isinstance(o, np.floating):
+        elif np_available and _isinstance_safe(o, np.floating):
             result = float(o)
         else:
             result = json.JSONEncoder.default(self, o)

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -1,0 +1,25 @@
+from dataclasses import dataclass
+
+from dataclasses_json import dataclass_json
+from dataclasses_json.core import np_available
+
+if np_available:
+    import numpy as np
+
+    @dataclass_json
+    @dataclass(frozen=True)
+    class DataWithNumpy:
+        int1: np.int64
+        float1: np.float64
+        array1: np.ndarray
+        array2: np.ndarray
+
+    d1 = DataWithNumpy(int1=np.int64(1), float1=np.float64(2.5),
+                       array1=np.array([1]), array2=np.array([2.5]))
+    d1_json = '{"int1": 1, "float1": 2.5, "array1": [1], "array2": [2.5]}'
+
+    class TestEncoder:
+        def test_data_with_numpy(self):
+            assert (
+                d1.to_json() == d1_json
+            ), f"Actual: {d1.to_json()}, Expected: {d1_json}"


### PR DESCRIPTION
Feel free to ignore if this is too much of an edge case for your module, but I found a need to serialise dataclasses to JSON that had NumPy types (int64 etc) in them. This PR adds support for encoding NumPy types, but only if the numpy module is available.
