### PR TITLE
serialization opt ignore_custom_naming added 

### DIFF
--- a/dataclasses_json/api.py
+++ b/dataclasses_json/api.py
@@ -34,9 +34,10 @@ class DataClassJsonMixin(abc.ABC):
                 indent: Optional[Union[int, str]] = None,
                 separators: Tuple[str, str] = None,
                 default: Callable = None,
+                ignore_custom_naming:bool = False,
                 sort_keys: bool = False,
                 **kw) -> str:
-        return json.dumps(self.to_dict(encode_json=False),
+        return json.dumps(self.to_dict(encode_json=False, ignore_custom_naming=ignore_custom_naming),
                           cls=_ExtendedEncoder,
                           skipkeys=skipkeys,
                           ensure_ascii=ensure_ascii,
@@ -71,8 +72,8 @@ class DataClassJsonMixin(abc.ABC):
                   infer_missing=False) -> A:
         return _decode_dataclass(cls, kvs, infer_missing)
 
-    def to_dict(self, encode_json=False) -> Dict[str, Json]:
-        return _asdict(self, encode_json=encode_json)
+    def to_dict(self, encode_json=False, ignore_custom_naming=False) -> Dict[str, Json]:
+        return _asdict(self, encode_json=encode_json, ignore_custom_naming=ignore_custom_naming)
 
     @classmethod
     def schema(cls: Type[A],

--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -93,10 +93,10 @@ def _encode_json_type(value, default=_ExtendedEncoder().default):
     return default(value)
 
 
-def _encode_overrides(kvs, overrides, encode_json=False):
+def _encode_overrides(kvs, overrides, encode_json=False, ignore_custom_naming=False):
     override_kvs = {}
     for k, v in kvs.items():
-        if k in overrides:
+        if k in overrides and ignore_custom_naming == False:
             exclude = overrides[k].exclude
             # If the exclude predicate returns true, the key should be
             #  excluded from encoding, so skip the rest of the loop
@@ -323,7 +323,7 @@ def _decode_items(type_arg, xs, infer_missing):
     return items
 
 
-def _asdict(obj, encode_json=False):
+def _asdict(obj, encode_json=False, ignore_custom_naming=False):
     """
     A re-implementation of `asdict` (based on the original in the `dataclasses`
     source) to support arbitrary Collection and Mapping types.
@@ -344,7 +344,7 @@ def _asdict(obj, encode_json=False):
         result = _handle_undefined_parameters_safe(cls=obj, kvs=dict(result),
                                                    usage="to")
         return _encode_overrides(dict(result), _user_overrides_or_exts(obj),
-                                 encode_json=encode_json)
+                                 encode_json=encode_json, ignore_custom_naming=ignore_custom_naming)
     elif isinstance(obj, Mapping):
         return dict((_asdict(k, encode_json=encode_json),
                      _asdict(v, encode_json=encode_json)) for k, v in

--- a/dataclasses_json/mm.py
+++ b/dataclasses_json/mm.py
@@ -337,11 +337,17 @@ def build_schema(cls: typing.Type[A],
     def dumps(self, *args, **kwargs):
         if 'cls' not in kwargs:
             kwargs['cls'] = _ExtendedEncoder
-
+        if "ignore_custom_naming" in kwargs and kwargs["ignore_custom_naming"]:
+            for attr_name, field_obj in self.dump_fields.items():
+                field_obj.data_key = None
+        if "ignore_custom_naming" in kwargs: kwargs.pop("ignore_custom_naming")
         return Schema.dumps(self, *args, **kwargs)
 
-    def dump(self, obj, *, many=None):
+    def dump(self, obj, *, many=None, ignore_custom_naming=False):
         many = self.many if many is None else bool(many)
+        if ignore_custom_naming:
+            for attr_name, field_obj in self.dump_fields.items():
+                field_obj.data_key = None
         dumped = Schema.dump(self, obj, many=many)
         # TODO This is hacky, but the other option I can think of is to generate a different schema
         #  depending on dump and load, which is even more hacky

--- a/tests/test_serialization_ignore.py
+++ b/tests/test_serialization_ignore.py
@@ -1,0 +1,113 @@
+from .test_letter_case import FieldNamePerson
+
+expected_ignore_json='{"given_name": "Alice"}'
+expected_json='{"givenName": "Alice"}'
+expected_ignore_dict={"given_name": "Alice"}
+expected_dict={"givenName": "Alice"}
+
+class TestSerializationIgnore:
+
+    def test_to_json_ignore_custom_naming(self):
+        assert expected_ignore_json == FieldNamePerson("Alice").to_json(ignore_custom_naming=True)
+
+    def test_to_json_include_custom_naming(self):
+        assert expected_json == FieldNamePerson("Alice").to_json(ignore_custom_naming=False)
+
+    def test_to_json_ignore_custom_naming_option(self):
+        assert expected_json == FieldNamePerson("Alice").to_json()
+
+    def test_to_dict_ignore_custom_naming(self):
+        assert expected_ignore_dict == FieldNamePerson("Alice").to_dict(ignore_custom_naming=True)
+
+    def test_to_dict_include_custom_naming(self):
+        assert expected_dict == FieldNamePerson("Alice").to_dict(ignore_custom_naming=False)
+
+    def test_to_dict_ignore_custom_naming_option(self):
+        assert expected_dict == FieldNamePerson("Alice").to_dict()
+
+    def test_dump_one_ignore_custom_naming(self):
+        person = FieldNamePerson('Alice')
+        dump = FieldNamePerson.schema().dump(person, many=False, ignore_custom_naming=True)
+        assert expected_ignore_dict == dump
+
+    def test_dump_one_include_custom_naming(self):
+        person = FieldNamePerson('Alice')
+        dump = FieldNamePerson.schema().dump(person, many=False, ignore_custom_naming=False)
+        assert expected_dict == dump
+
+    def test_dump_one_ignore_custom_naming_option(self):
+        person = FieldNamePerson('Alice')
+        dump = FieldNamePerson.schema().dump(person, many=False)
+        assert expected_dict == dump
+
+    def test_dumps_one_ignore_custom_naming(self):
+        person = FieldNamePerson('Alice')
+        dump = FieldNamePerson.schema().dumps(person, many=False, ignore_custom_naming=True)
+        assert expected_ignore_json == dump
+
+    def test_dumps_one_include_custom_naming(self):
+        person = FieldNamePerson('Alice')
+        dump = FieldNamePerson.schema().dumps(person, many=False, ignore_custom_naming=False)
+        assert expected_json == dump
+
+    def test_dumps_one_ignore_custom_naming_option(self):
+        person = FieldNamePerson('Alice')
+        dump = FieldNamePerson.schema().dumps(person, many=False)
+        assert expected_json == dump
+
+    def test_dump_many_ignore_custom_naming(self):
+        p1 = FieldNamePerson('Alice')
+        p2 = FieldNamePerson('Alex')
+        dump = FieldNamePerson.schema().dump([p1,p2], many=True, ignore_custom_naming=True)
+        p1_dict = p1.to_dict(ignore_custom_naming=True)
+        p2_dict = p2.to_dict(ignore_custom_naming=True)
+        assert len(dump) == 2
+        assert p1_dict in dump
+        assert p2_dict in dump
+
+    def test_dump_many_include_custom_naming(self):
+        p1 = FieldNamePerson('Alice')
+        p2 = FieldNamePerson('Alex')
+        dump = FieldNamePerson.schema().dump([p1,p2], many=True, ignore_custom_naming=False)
+        p1_dict = p1.to_dict(ignore_custom_naming=False)
+        p2_dict = p2.to_dict(ignore_custom_naming=False)
+        assert len(dump) == 2
+        assert p1_dict in dump
+        assert p2_dict in dump
+
+    def test_dump_many_ignore_custom_naming_option(self):
+        p1 = FieldNamePerson('Alice')
+        p2 = FieldNamePerson('Alex')
+        dump = FieldNamePerson.schema().dump([p1,p2], many=True)
+        p1_dict = p1.to_dict()
+        p2_dict = p2.to_dict()
+        assert len(dump) == 2
+        assert p1_dict in dump
+        assert p2_dict in dump
+
+    def test_dumps_many_ignore_custom_naming(self):
+        p1 = FieldNamePerson('Alice')
+        p2 = FieldNamePerson('Alex')
+        dump = FieldNamePerson.schema().dumps([p1,p2], many=True, ignore_custom_naming=True)
+        p1_json = p1.to_json(ignore_custom_naming=True)
+        p2_json = p2.to_json(ignore_custom_naming=True)
+        assert p1_json in dump
+        assert p2_json in dump
+
+    def test_dumps_many_include_custom_naming(self):
+        p1 = FieldNamePerson('Alice')
+        p2 = FieldNamePerson('Alex')
+        dump = FieldNamePerson.schema().dumps([p1,p2], many=True, ignore_custom_naming=False)
+        p1_json = p1.to_json(ignore_custom_naming=False)
+        p2_json = p2.to_json(ignore_custom_naming=False)
+        assert p1_json in dump
+        assert p2_json in dump
+
+    def test_dumps_many_ignore_custom_naming_option(self):
+        p1 = FieldNamePerson('Alice')
+        p2 = FieldNamePerson('Alex')
+        dump = FieldNamePerson.schema().dumps([p1,p2], many=True)
+        p1_json = p1.to_json()
+        p2_json = p2.to_json()
+        assert p1_json in dump
+        assert p2_json in dump


### PR DESCRIPTION
Added default param "ignore_custom_naming=False" which will ignore "field_name" metadata config on serialization.
```
field(metadata=config(field_name='givenName'))
```
Implemented for all of the serialization methods:
```python
.to_dict(ignore_custom_naming=False)
.to_json(ignore_custom_naming=False)
.schema().dump(ignore_custom_naming=False)
.schema().dumps(ignore_custom_naming=False)
```

The purpose of this PR is to be able to easily serialize external "ugly" naming conventions into desired objects 