### PR TITLE
Fix deserialization for typing.Counter

### DIFF
--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -11,7 +11,8 @@ from dataclasses import (MISSING,
 from datetime import datetime, timezone
 from decimal import Decimal
 from enum import Enum
-from typing import Any, Collection, Mapping, Union, get_type_hints, Tuple
+from typing import (Any, Collection, Counter, Mapping,
+                    Union, get_type_hints, Tuple)
 from uuid import UUID
 
 from typing_inspect import is_union_type  # type: ignore
@@ -19,9 +20,9 @@ from typing_inspect import is_union_type  # type: ignore
 from dataclasses_json import cfg
 from dataclasses_json.utils import (_get_type_cons, _get_type_origin,
                                     _handle_undefined_parameters_safe,
-                                    _is_collection, _is_mapping, _is_new_type,
-                                    _is_optional, _isinstance_safe,
-                                    _issubclass_safe)
+                                    _is_collection, _is_counter, _is_mapping, 
+                                    _is_new_type, _is_optional, 
+                                    _isinstance_safe, _issubclass_safe)
 
 Json = Union[dict, list, str, int, float, bool, None]
 
@@ -247,7 +248,7 @@ def _decode_generic(type_, value, infer_missing):
         res = type_(value)
     # FIXME this is a hack to fix a deeper underlying issue. A refactor is due.
     elif _is_collection(type_):
-        if _is_mapping(type_):
+        if _is_mapping(type_) and not _is_counter(type_):
             k_type, v_type = getattr(type_, "__args__", (Any, Any))
             # a mapping type has `.keys()` and `.values()`
             # (see collections.abc)

--- a/dataclasses_json/utils.py
+++ b/dataclasses_json/utils.py
@@ -1,7 +1,7 @@
 import inspect
 import sys
 from datetime import datetime, timezone
-from typing import Collection, Mapping, Optional, TypeVar, Any
+from typing import Collection, Counter, Mapping, Optional, TypeVar, Any
 
 
 def _get_type_cons(type_):
@@ -100,6 +100,10 @@ def _is_optional(type_):
 
 def _is_mapping(type_):
     return _issubclass_safe(_get_type_origin(type_), Mapping)
+
+
+def _is_counter(type_):
+    return _issubclass_safe(_get_type_origin(type_), Counter)
 
 
 def _is_collection(type_):

--- a/tests/entities.py
+++ b/tests/entities.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, field
 from decimal import Decimal
 from typing import (Collection,
+                    Counter,
                     Deque,
                     Dict,
                     FrozenSet,
@@ -273,3 +274,9 @@ class DataClassWithNestedOptional:
 @dataclass
 class DataClassWithNestedDictWithTupleKeys:
     a: Dict[Tuple[int], int]
+
+
+@dataclass_json
+@dataclass
+class DataClassWithCounter:
+    c: Counter[str]

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -1,14 +1,15 @@
-from collections import deque
+from collections import Counter, deque
 
 from tests.entities import (DataClassIntImmutableDefault,
                             DataClassMutableDefaultDict,
-                            DataClassMutableDefaultList, DataClassWithDeque,
-                            DataClassWithDict, DataClassWithDictInt,
-                            DataClassWithFrozenSet, DataClassWithList,
-                            DataClassWithListStr, DataClassWithMyCollection,
-                            DataClassWithOptional, DataClassWithOptionalStr,
-                            DataClassWithSet, DataClassWithTuple,
-                            DataClassWithUnionIntNone, MyCollection)
+                            DataClassMutableDefaultList, DataClassWithCounter,
+                            DataClassWithDeque, DataClassWithDict,
+                            DataClassWithDictInt, DataClassWithFrozenSet,
+                            DataClassWithList, DataClassWithListStr,
+                            DataClassWithMyCollection, DataClassWithOptional,
+                            DataClassWithOptionalStr, DataClassWithSet,
+                            DataClassWithTuple, DataClassWithUnionIntNone,
+                            MyCollection)
 
 
 class TestEncoder:
@@ -22,7 +23,8 @@ class TestEncoder:
         assert DataClassWithDict({'1': 'a'}).to_json() == '{"kvs": {"1": "a"}}'
 
     def test_dict_int(self):
-        assert DataClassWithDictInt({1: 'a'}).to_json() == '{"kvs": {"1": "a"}}'
+        assert DataClassWithDictInt(
+            {1: 'a'}).to_json() == '{"kvs": {"1": "a"}}'
 
     def test_set(self):
         assert DataClassWithSet({1}).to_json() == '{"xs": [1]}'
@@ -31,7 +33,8 @@ class TestEncoder:
         assert DataClassWithTuple((1,)).to_json() == '{"xs": [1]}'
 
     def test_frozenset(self):
-        assert DataClassWithFrozenSet(frozenset([1])).to_json() == '{"xs": [1]}'
+        assert DataClassWithFrozenSet(
+            frozenset([1])).to_json() == '{"xs": [1]}'
 
     def test_deque(self):
         assert DataClassWithDeque(deque([1])).to_json() == '{"xs": [1]}'
@@ -61,6 +64,10 @@ class TestEncoder:
 
     def test_mutable_default_dict(self):
         assert DataClassMutableDefaultDict().to_json() == '{"xs": {}}'
+
+    def test_counter(self):
+        assert DataClassWithCounter(
+            c=Counter('foo')).to_json() == '{"c": {"f": 1, "o": 2}}'
 
 
 class TestDecoder:
@@ -131,3 +138,7 @@ class TestDecoder:
                 == DataClassMutableDefaultDict())
         assert (DataClassMutableDefaultDict.from_json('{}', infer_missing=True)
                 == DataClassMutableDefaultDict())
+
+    def test_counter(self):
+        assert DataClassWithCounter.from_json(
+            '{"c": {"f": 1, "o": 2}}') == DataClassWithCounter(c=Counter('foo'))


### PR DESCRIPTION
The issue here is that typing.Counter deserialization ends ups in the generic deserialization block. And because Counter is a mapping, we try to get key and value type of it. But it fails, and we shouldn't really deserialize a counter that way. This PR fixes it and deserializes it properly

Example test:
```py3
$ cat test.py
from dataclasses_json import dataclass_json
from dataclasses import dataclass
import typing
import collections

@dataclass_json
@dataclass
class C:
    c: typing.Counter[str]

c = C(collections.Counter('aba'))
print(c.to_json())
print(C.from_json('{"c":{"a":2,"b":1}}'))
```

Before:
```bash
$ py3 test.py
{"c": {"a": 2, "b": 1}}
Traceback (most recent call last):
  File "/Users/hrenic/test.py", line 13, in <module>
    print(C.from_json('{"c":{"a":2,"b":1}}'))
  File "/opt/homebrew/lib/python3.9/site-packages/dataclasses_json-0.5.7-py3.9.egg/dataclasses_json/api.py", line 65, in from_json
  File "/opt/homebrew/lib/python3.9/site-packages/dataclasses_json-0.5.7-py3.9.egg/dataclasses_json/api.py", line 72, in from_dict
  File "/opt/homebrew/lib/python3.9/site-packages/dataclasses_json-0.5.7-py3.9.egg/dataclasses_json/core.py", line 202, in _decode_dataclass
  File "/opt/homebrew/lib/python3.9/site-packages/dataclasses_json-0.5.7-py3.9.egg/dataclasses_json/core.py", line 255, in _decode_generic
ValueError: not enough values to unpack (expected 2, got 1)
```

After: 
```bash
$ py3 test.py
{"c": {"a": 2, "b": 1}}
C(c=Counter({'a': 2, 'b': 1}))
```
