### PR TITLE
Restore `schema()` type safety by fixing generic type alias misuse

### DIFF
--- a/dataclasses_json/api.py
+++ b/dataclasses_json/api.py
@@ -85,7 +85,7 @@ class DataClassJsonMixin(abc.ABC):
                load_only=(),
                dump_only=(),
                partial: bool = False,
-               unknown=None) -> SchemaType:
+               unknown=None) -> "SchemaType[A]":
         Schema = build_schema(cls, DataClassJsonMixin, infer_missing, partial)
 
         if unknown is None:

--- a/dataclasses_json/mm.py
+++ b/dataclasses_json/mm.py
@@ -140,7 +140,7 @@ TEncoded = typing.Dict[str, typing.Any]
 TOneOrMulti = typing.Union[typing.List[A], A]
 TOneOrMultiEncoded = typing.Union[typing.List[TEncoded], TEncoded]
 
-if sys.version_info >= (3, 7):
+if sys.version_info >= (3, 7) or typing.TYPE_CHECKING:
     class SchemaF(Schema, typing.Generic[A]):
         """Lift Schema into a type constructor"""
 
@@ -319,7 +319,7 @@ def schema(cls, mixin, infer_missing):
 def build_schema(cls: typing.Type[A],
                  mixin,
                  infer_missing,
-                 partial) -> typing.Type[SchemaType]:
+                 partial) -> typing.Type["SchemaType[A]"]:
     Meta = type('Meta',
                 (),
                 {'fields': tuple(field.name for field in dc_fields(cls)
@@ -359,7 +359,7 @@ def build_schema(cls: typing.Type[A],
         return dumped
 
     schema_ = schema(cls, mixin, infer_missing)
-    DataClassSchema: typing.Type[SchemaType] = type(
+    DataClassSchema: typing.Type["SchemaType[A]"] = type(
         f'{cls.__name__.capitalize()}Schema',
         (Schema,),
         {'Meta': Meta,


### PR DESCRIPTION
Type arguments for a generic type alias must be provided at every use site, or the missing arguments will default to `Any`, which gives no type safety.

Fixes #370.