### PR TITLE
Update usage of mypy.main in test following updates to mypy package

### DIFF
--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -105,7 +105,7 @@ class TestAnnotations:
         try:
             # mypy.main uses sys.stdout for printing
             # We override it to catch error messages
-            mypy_main(None, text_io, text_io, [__file__], clean_exit=True)
+            mypy_main(args=[__file__], stdout=text_io, stderr=text_io, clean_exit=True)
         except SystemExit:
             # mypy.main could return errors found inside other files.
             # filter_errors() will filter out all errors outside this file.


### PR DESCRIPTION
Last month, a **mypy** change was released that made all arguments for the `mypy.main` method **keyword** only. They also removed an unused argument. 

https://github.com/python/mypy/pull/13399

The alternative to this change is to freeze your version of `mypy`
