### PR TITLE
Drop marshmallow-enum dependency

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,8 +9,7 @@ mypy = "*"
 pytest = "6.2.3"
 
 [packages]
-marshmallow = "*"
-marshmallow-enum = "*"
+marshmallow = ">=3.18.0"
 stringcase = "*"
 typing-inspect = "*"
 

--- a/dataclasses_json/mm.py
+++ b/dataclasses_json/mm.py
@@ -14,7 +14,6 @@ from enum import Enum
 from typing_inspect import is_union_type  # type: ignore
 
 from marshmallow import fields, Schema, post_load  # type: ignore
-from marshmallow_enum import EnumField  # type: ignore
 from marshmallow.exceptions import ValidationError  # type: ignore
 
 from dataclasses_json.core import (_is_supported_generic, _decode_dataclass,
@@ -253,7 +252,7 @@ def build_type(type_, options, mixin, field, cls):
             return TYPES[origin](*args, **options)
 
         if _issubclass_safe(origin, Enum):
-            return EnumField(enum=origin, by_value=True, *args, **options)
+            return fields.Enum(enum=origin, by_value=True, *args, **options)
 
         if is_union_type(type_):
             union_types = [a for a in getattr(type_, '__args__', []) if

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,7 @@ setup(
     keywords='dataclasses json',
     install_requires=[
         'dataclasses;python_version=="3.6"',
-        'marshmallow>=3.3.0,<4.0.0',
-        'marshmallow-enum>=1.5.1,<2.0.0',
+        'marshmallow>=3.18.0,<4.0.0',
         'typing-inspect>=0.4.0'
     ],
     python_requires='>=3.6',


### PR DESCRIPTION
According to #380 this PR drops [marshmallow-enum](https://github.com/justanr/marshmallow_enum) dependency, which is now an archive. 
Enum type is supported since marshmallow 3.18.0.