### PR TITLE
Fixed a bug when using a `list`.

### DIFF
--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -261,8 +261,14 @@ def _decode_generic(type_, value, infer_missing):
             vs = _decode_items(v_type, value.values(), infer_missing)
             xs = zip(ks, vs)
         else:
-            xs = _decode_items(_get_type_arg_param(type_, 0),
-                               value, infer_missing)
+            # Fixed a bug when generic type `list`
+            #   => AttributeError: type object 'list' has no attribute `__args__`
+            # Detect if type hasattr `__args__`.
+            # if not => just return `xs` as a deepcopy of `value`
+            if hasattr(type, "__args__"):
+                xs = _decode_items(type_.__args__[0], value, infer_missing)
+            else:
+                xs = copy.deepcopy(value)
 
         # get the constructor if using corresponding generic type in `typing`
         # otherwise fallback on constructing using type_ itself


### PR DESCRIPTION
Hello. It's my first PR.

## When you try to create a "list", python throw error:
##    => AttributeError: type object 'list' has no attribute `__args__`

### Example:
```Python
import json
from dataclasses import dataclass, field
from dataclasses_json import dataclass_json

@dataclass_json
@dataclass
class Test:
    var_a: str = ""
    var_b: int = -1
    var_c: list = field(default_factory=list)
    var_d: dict = field(default_factory=dict)

def write(data: dict, json_file: str):
    with open(json_file, "w") as fd:
        json.dump(data, fd, indent=4)

def read(json_file: str):
    with open(json_file, "r") as fd:
        data = json.load(fd)
    return data

FILE = "testing.json"

test = Test(
    var_a="hello",
    var_b=100,
    var_c=["a", "b", "c"],
    var_d={"a": 0, "b": 1, "c": 2}
)
print(test)
write(test.to_dict(), FILE)

dtest = read(FILE)
test = Test.from_dict(dtest)

print(test)
```