### PR TITLE
#395: fields with no default value/factory should be marked as required when generating schema

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -15,7 +15,7 @@ jobs:
       max-parallel: 5
       matrix:
         # https://github.com/actions/python-versions/blob/main/versions-manifest.json
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
 
     steps:
     - uses: actions/checkout@v1

--- a/dataclasses_json/mm.py
+++ b/dataclasses_json/mm.py
@@ -282,18 +282,19 @@ def schema(cls, mixin, infer_missing):
     # TODO check the undefined parameters and add the proper schema action
     #  https://marshmallow.readthedocs.io/en/stable/quickstart.html
     for field in dc_fields(cls):
-        metadata = (field.metadata or {}).get('dataclasses_json', {})
         metadata = overrides[field.name]
         if metadata.mm_field is not None:
             schema[field.name] = metadata.mm_field
         else:
             type_ = field.type
-            options = {}
+            options: typing.Dict[str, any] = {}
             missing_key = 'missing' if infer_missing else 'default'
             if field.default is not MISSING:
                 options[missing_key] = field.default
             elif field.default_factory is not MISSING:
                 options[missing_key] = field.default_factory
+            else:
+                options['required'] = True
 
             if options.get(missing_key, ...) is None:
                 options['allow_none'] = True
@@ -346,7 +347,7 @@ def build_schema(cls: typing.Type[A],
         # TODO This is hacky, but the other option I can think of is to generate a different schema
         #  depending on dump and load, which is even more hacky
 
-        # The only problem is the catch all field, we can't statically create a schema for it
+        # The only problem is the catch-all field, we can't statically create a schema for it,
         # so we just update the dumped dict
         if many:
             for i, _obj in enumerate(obj):
@@ -369,5 +370,3 @@ def build_schema(cls: typing.Type[A],
          **schema_})
 
     return DataClassSchema
-
-

--- a/dataclasses_json/mm.py
+++ b/dataclasses_json/mm.py
@@ -287,7 +287,7 @@ def schema(cls, mixin, infer_missing):
             schema[field.name] = metadata.mm_field
         else:
             type_ = field.type
-            options: typing.Dict[str, any] = {}
+            options: typing.Dict[str, typing.Any] = {}
             missing_key = 'missing' if infer_missing else 'default'
             if field.default is not MISSING:
                 options[missing_key] = field.default

--- a/tests/entities.py
+++ b/tests/entities.py
@@ -157,6 +157,11 @@ class DataClassWithOptional(DataClassJsonMixin):
 
 
 @dataclass(frozen=True)
+class DataClassWithOptionalWithDefault(DataClassJsonMixin):
+    x: Optional[int] = None
+
+
+@dataclass(frozen=True)
 class DataClassWithOptionalUnbound(DataClassJsonMixin):
     x: Optional
 
@@ -169,6 +174,11 @@ class DataClassWithOptionalStr(DataClassJsonMixin):
 @dataclass(frozen=True)
 class DataClassWithOptionalNested(DataClassJsonMixin):
     x: Optional[DataClassWithOptional]
+
+
+@dataclass(frozen=True)
+class DataClassWithOptionalNestedWithDefault(DataClassJsonMixin):
+    x: Optional[DataClassWithOptional] = None
 
 
 @dataclass(frozen=True)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -18,7 +18,9 @@ from tests.entities import (DataClassBoolImmutableDefault,
                             DataClassWithOptionalDecimal,
                             DataClassWithOptionalNested,
                             DataClassWithOptionalUuid, DataClassWithUuid, UUIDWrapper,
-                            UUIDWrapperWrapper)
+                            UUIDWrapperWrapper,
+                            DataClassWithOptionalWithDefault,
+                            DataClassWithOptionalNestedWithDefault)
 
 
 class TestTypes:
@@ -218,15 +220,15 @@ class TestSchema:
             d_new_type) == f'{{"id": "{raw_value}"}}'
 
     def test_loads_infer_missing(self):
-        assert (DataClassWithOptional
+        assert (DataClassWithOptionalWithDefault
                 .schema(infer_missing=True)
-                .loads('[{}]', many=True) == [DataClassWithOptional(None)])
+                .loads('[{}]', many=True) == [DataClassWithOptionalWithDefault(None)])
 
     def test_loads_infer_missing_nested(self):
-        assert (DataClassWithOptionalNested
+        assert (DataClassWithOptionalNestedWithDefault
                 .schema(infer_missing=True)
                 .loads('[{}]', many=True) == [
-                    DataClassWithOptionalNested(None)])
+                    DataClassWithOptionalNestedWithDefault(None)])
 
 
 class TestOverride:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,3 +1,6 @@
+import marshmallow
+import pytest
+
 from .entities import (DataClassDefaultListStr, DataClassDefaultOptionalList, DataClassList, DataClassOptional,
                        DataClassWithNestedOptional, DataClassWithNestedOptionalAny, DataClassWithNestedAny)
 from .test_letter_case import CamelCasePerson, KebabCasePerson, SnakeCasePerson, FieldNamePerson
@@ -23,6 +26,10 @@ class TestSchema:
     def test_optional(self):
         DataClassOptional.schema().loads('{"a": 4, "b": null}')
         assert True
+
+    def test_not_providing_required_field(self):
+        with pytest.raises(marshmallow.ValidationError):
+            DataClassOptional.schema.loads('{"b": null}')
 
     def test_letter_case(self):
         for cls in (CamelCasePerson, KebabCasePerson, SnakeCasePerson, FieldNamePerson):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -29,7 +29,7 @@ class TestSchema:
 
     def test_not_providing_required_field(self):
         with pytest.raises(marshmallow.ValidationError):
-            DataClassOptional.schema.loads('{"b": null}')
+            DataClassOptional.schema().loads('{"b": null}')
 
     def test_letter_case(self):
         for cls in (CamelCasePerson, KebabCasePerson, SnakeCasePerson, FieldNamePerson):


### PR DESCRIPTION
When generating a marshmallow schema for a dataclass, fields that have no default value or default factory should be marked as required, so that when deserializing an object into the dataclass, a missing value for the field will result in a proper Validation error instead of a KeyError.