### PR TITLE
Use getter for Optional fields

### DIFF
--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -160,7 +160,7 @@ def _decode_dataclass(cls, kvs, infer_missing):
         if not field.init:
             continue
 
-        field_value = kvs[field.name]
+        field_value = kvs.get(field.name)
         field_type = types[field.name]
         if field_value is None and not _is_optional(field_type):
             warning = (f"value of non-optional type {field.name} detected "


### PR DESCRIPTION
Summary:
Use getter instead of [], so one can specify optional fields.

Test Plan:
Define a dataclass w/ an Optional field.
Feed it a Dict w/o that field present.
Observe exception.
Patch the code.
Do it again, observe the field is now a `None`