### PR TITLE
Fix: default_factory returned without being called when filling default value in schema

### DIFF
--- a/dataclasses_json/mm.py
+++ b/dataclasses_json/mm.py
@@ -293,7 +293,7 @@ def schema(cls, mixin, infer_missing):
             if field.default is not MISSING:
                 options[missing_key] = field.default
             elif field.default_factory is not MISSING:
-                options[missing_key] = field.default_factory
+                options[missing_key] = field.default_factory()
 
             if options.get(missing_key, ...) is None:
                 options['allow_none'] = True


### PR DESCRIPTION
The default_factory is a factory for generating the default value. For example, to get a default of `[]`, the default_factory will be `list`.

Without calling the factory, the schema will be filled with, in this case, `"<class: 'list'>"`. Whereas if you call the factory, the default will correctly be set to `[]`.