### PR TITLE
feat: use default value in not optional field.

### DIFF
--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -173,7 +173,12 @@ def _decode_dataclass(cls, kvs, infer_missing):
                     f"behavior.", RuntimeWarning)
             else:
                 warnings.warn(f"`NoneType` object {warning}.", RuntimeWarning)
-            init_kwargs[field.name] = field_value
+            if hasattr(field, "default"):
+                init_kwargs[field.name] = field.default
+            elif hasattr(field, "default"):
+                init_kwargs[field.name] = field.default_factory()
+            else:
+                init_kwargs[field.name] = field_value
             continue
 
         while True:


### PR DESCRIPTION
Case 1:
The upstream has passed a value that may be empty. This empty value has no business meaning. It is hoped that the dataclass_json layer can be completed instead of introducing more types to reduce the complexity of subsequent business logic.
```
{
  "a": null
}

{
  "a": ["1,2,3"]
}
```

```
a: Tuple[str] = ()
```