### PR TITLE
Removes unused type variables in api.py

### DIFF
--- a/dataclasses_json/api.py
+++ b/dataclasses_json/api.py
@@ -12,8 +12,6 @@ from dataclasses_json.utils import (_handle_undefined_parameters_safe,
                                     _undefined_parameter_action_safe)
 
 A = TypeVar('A', bound="DataClassJsonMixin")
-B = TypeVar('B')
-C = TypeVar('C')
 Fields = List[Tuple[str, Any]]
 
 


### PR DESCRIPTION
Fixes #364 

Simply removes two unused type variables in `api.py`. This has no functional impact.