### PR TITLE
Fixes bug in string case serialization not taking numbers into account

### DIFF
--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -115,7 +115,10 @@ def _encode_overrides(kvs, overrides, encode_json=False):
             original_key = k
             k = letter_case(k) if letter_case is not None else k
             if k in override_kvs:
-                raise ValueError(f"Multiple fields map to the same JSON key after letter case encoding: {k}")
+                raise ValueError(
+                    f"Multiple fields map to the same JSON "
+                    f"key after letter case encoding: {k}"
+                )
 
             encoder = overrides[original_key].encoder
             v = encoder(v) if encoder is not None else v

--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -114,6 +114,8 @@ def _encode_overrides(kvs, overrides, encode_json=False):
             letter_case = overrides[k].letter_case
             original_key = k
             k = letter_case(k) if letter_case is not None else k
+            if k in override_kvs:
+                raise ValueError(f"Multiple fields map to the same JSON key after letter case encoding: {k}")
 
             encoder = overrides[original_key].encoder
             v = encoder(v) if encoder is not None else v

--- a/dataclasses_json/stringcase.py
+++ b/dataclasses_json/stringcase.py
@@ -75,7 +75,7 @@ def camelcase(string):
     if not string:
         return string
     return (uplowcase(string[0], 'low')
-            + re.sub(r"[\-_\.\s]([a-z])",
+            + re.sub(r"[\-_\.\s]([a-z0-9])",
                      lambda matched: uplowcase(matched.group(1), 'up'),
                      string[1:]))
 
@@ -96,7 +96,7 @@ def snakecase(string):
     if not string:
         return string
     return (uplowcase(string[0], 'low')
-            + re.sub(r"[A-Z]",
+            + re.sub(r"[A-Z0-9]",
                      lambda matched: '_' + uplowcase(matched.group(0), 'low'),
                      string[1:]))
 

--- a/tests/test_letter_case.py
+++ b/tests/test_letter_case.py
@@ -76,6 +76,21 @@ class CamelCaseProtectedNamePerson:
     )
 
 
+@dataclass_json
+@dataclass
+class CamelCaseDuplicatedNameEncodingPerson:
+    given_name_1: str = field(
+        metadata={'dataclasses_json': {
+            'letter_case': LetterCase.CAMEL
+        }}
+    )
+    given_name1: str = field(
+        metadata={'dataclasses_json': {
+            'letter_case': LetterCase.CAMEL
+        }}
+    )
+
+
 class TestLetterCase:
     def test_camel_encode(self):
         assert CamelCasePerson('Alice').to_json() == '{"givenName": "Alice"}'
@@ -133,3 +148,7 @@ class TestLetterCase:
 
     def test_protected_decode(self):
         assert CamelCaseProtectedNamePerson.from_json('{"givenName2": "Alice"}') == CamelCaseProtectedNamePerson('Alice')
+
+    def test_duplicated_encoding(self):
+        with pytest.raises(ValueError):
+            CamelCaseDuplicatedNameEncodingPerson('Alice', 'Bob').to_json()

--- a/tests/test_letter_case.py
+++ b/tests/test_letter_case.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass, field
 
+import pytest
+
 from dataclasses_json import LetterCase, dataclass_json, config
 
 
@@ -54,16 +56,6 @@ class FieldNamePerson:
 class CamelCasePersonWithOverride:
     given_name: str
     years_on_earth: int = field(metadata=config(field_name='age'))
-
-
-@dataclass_json
-@dataclass
-class CamelCaseProtectedNamePerson:
-    _given_name_2: str = field(
-        metadata={'dataclasses_json': {
-            'letter_case': LetterCase.CAMEL
-        }}
-    )
 
 
 @dataclass_json

--- a/tests/test_letter_case.py
+++ b/tests/test_letter_case.py
@@ -56,6 +56,16 @@ class CamelCasePersonWithOverride:
     years_on_earth: int = field(metadata=config(field_name='age'))
 
 
+@dataclass_json
+@dataclass
+class CamelCaseProtectedNamePerson:
+    _given_name_2: str = field(
+        metadata={'dataclasses_json': {
+            'letter_case': LetterCase.CAMEL
+        }}
+    )
+
+
 class TestLetterCase:
     def test_camel_encode(self):
         assert CamelCasePerson('Alice').to_json() == '{"givenName": "Alice"}'
@@ -107,3 +117,9 @@ class TestLetterCase:
 
     def test_to_dict(self):
         assert {'givenName': 'Alice'} == CamelCasePerson('Alice').to_dict()
+
+    def test_protected_encode(self):
+        assert CamelCaseProtectedNamePerson('Alice').to_json() == '{"givenName2": "Alice"}'
+
+    def test_protected_decode(self):
+        assert CamelCaseProtectedNamePerson.from_json('{"givenName2": "Alice"}') == CamelCaseProtectedNamePerson('Alice')


### PR DESCRIPTION
As described in #376, the camelCase serialization does not remove underscores in front of numbers. I believe it should - let me know what you think.