### PR TITLE
Checkout with crlf correction

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -23,6 +23,7 @@ jobs:
 
     if: github.ref != 'refs/heads/main'
     steps:
+      - run: git config --global core.autocrlf input
       - uses: actions/checkout@v3
 
       - uses: actions/setup-python@v4

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -9,7 +9,8 @@ jobs:
     if: ${{ github.ref == 'refs/heads/master' }}
 
     steps:
-      - uses: actions/checkout@v2
+      - run: git config --global core.autocrlf input
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Create Release

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -22,6 +22,7 @@ jobs:
         python-version: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12"]
 
     steps:
+    - run: git config --global core.autocrlf input
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4


### PR DESCRIPTION
Fixes #461 

Updates git config to use `autocrlf=input` before running a checkout action on all workflows