### PR TITLE
improve Union deserialization when "__type" field specifier is not present

### DIFF
--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -314,19 +314,17 @@ def _decode_generic(type_, value, infer_missing):
             type_options = _get_type_args(type_)
             res = value  # assume already decoded
             if type(value) is dict and dict not in type_options:
-                changed = False
                 for type_option in type_options:
                     if is_dataclass(type_option):
                         try:
                             res = _decode_dataclass(type_option, value, infer_missing)
-                            changed = True
                             break
                         except (KeyError, ValueError):
                             continue
-                if not changed:
+                if res == value:
                     warnings.warn(
-                        f"Failed to encode {value} Union dataclasses."
-                        f"Expected Union to include a dataclass and it didn't."
+                        f"Failed to decode {value} Union dataclasses."
+                        f"Expected Union to include a matching dataclass and it didn't."
                     )
     return res
 

--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -325,7 +325,7 @@ def _decode_generic(type_, value, infer_missing):
                             continue
                 if not changed:
                     warnings.warn(
-                        f"Failed encoding {value} Union dataclasses."
+                        f"Failed to encode {value} Union dataclasses."
                         f"Expected Union to include a dataclass and it didn't."
                     )
     return res

--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -312,10 +312,8 @@ def _decode_generic(type_, value, infer_missing):
                 res = _support_extended_types(type_arg, value)
         else:  # Union (already decoded or try to decode a dataclass)
             type_options = _get_type_args(type_)
-            if type(value) is not dict or dict in type_options:
-                # already decoded
-                res = value
-            else:
+            res = value
+            if type(value) is dict and dict not in type_options:
                 changed = False
                 for type_option in type_options:
                     if is_dataclass(type_option):
@@ -326,7 +324,6 @@ def _decode_generic(type_, value, infer_missing):
                         except (KeyError, ValueError):
                             continue
                 if not changed:
-                    res = value
                     warnings.warn(
                         f"Failed encoding {value} Union dataclasses."
                         f"Expected Union to include a dataclass and it didn't."

--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -312,7 +312,7 @@ def _decode_generic(type_, value, infer_missing):
                 res = _support_extended_types(type_arg, value)
         else:  # Union (already decoded or try to decode a dataclass)
             type_options = _get_type_args(type_)
-            res = value
+            res = value # assume already decoded
             if type(value) is dict and dict not in type_options:
                 changed = False
                 for type_option in type_options:

--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -312,7 +312,7 @@ def _decode_generic(type_, value, infer_missing):
                 res = _support_extended_types(type_arg, value)
         else:  # Union (already decoded or try to decode a dataclass)
             type_options = _get_type_args(type_)
-            res = value # assume already decoded
+            res = value  # assume already decoded
             if type(value) is dict and dict not in type_options:
                 changed = False
                 for type_option in type_options:

--- a/tests/test_union.py
+++ b/tests/test_union.py
@@ -39,8 +39,18 @@ class Aux2:
 
 @dataclass_json
 @dataclass
+class Aux3:
+    f2: str
+
+@dataclass_json
+@dataclass
 class C4:
     f1: Union[Aux1, Aux2]
+
+@dataclass_json
+@dataclass
+class C12:
+    f1: Union[Aux2, Aux3]
 
 
 @dataclass_json
@@ -198,3 +208,29 @@ def test_deserialize_with_error(cls, data):
     s = cls.schema()
     with pytest.raises(ValidationError):
         assert s.load(data)
+
+def test_deserialize_without_discriminator():
+    # determine based on type
+    json = '{"f1": {"f1": 1}}'
+    s = C4.schema()
+    obj = s.loads(json)
+    assert obj.f1 is not None
+    assert type(obj.f1) == Aux1
+
+    json = '{"f1": {"f1": "str1"}}'
+    s = C4.schema()
+    obj = s.loads(json)
+    assert obj.f1 is not None
+    assert type(obj.f1) == Aux2
+
+    # determine based on field name
+    json = '{"f1": {"f1": "str1"}}'
+    s = C12.schema()
+    obj = s.loads(json)
+    assert obj.f1 is not None
+    assert type(obj.f1) == Aux2
+    json = '{"f1": {"f2": "str1"}}'
+    s = C12.schema()
+    obj = s.loads(json)
+    assert obj.f1 is not None
+    assert type(obj.f1) == Aux3

--- a/tests/test_union.py
+++ b/tests/test_union.py
@@ -234,3 +234,9 @@ def test_deserialize_without_discriminator():
     obj = s.loads(json)
     assert obj.f1 is not None
     assert type(obj.f1) == Aux3
+
+    # if no matching types, type should remain dict
+    json = '{"f1": {"f3": "str2"}}'
+    s = C12.schema()
+    obj = s.loads(json)
+    assert type(obj.f1) == dict


### PR DESCRIPTION
This pull request adds a best-effort deserialization to Union types when no `__type` field specifier is present.

In the case that no `__type` field is present, a warning is issued describing the risk of such unmarshalling attempt.

We attempt to decode ensuring that keys exist on the type, and the values are appropriate.  If either of these conditions fails, we abandon that dataclass type, and move onto the next one.

If no type is found, a warning is issued, the value is not decoded, and is left as-is.
