### PR TITLE
Add links to make PyPI a better maintainer reference

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,9 @@ maintainers = ['Charles Li <charles.dt.li@gmail.com>', 'Georgiy Zubrienko <gzu@e
 license = 'MIT'
 readme = "README.md"
 repository = 'https://github.com/lidatong/dataclasses-json'
+changelog = "https://github.com/lidatong/dataclasses-json/releases"
+documentation = "https://lidatong.github.io/dataclasses-json/"
+issues = "https://github.com/lidatong/dataclasses-json/issues"
 
 [tool.poetry.dependencies]
 python = "^3.7"


### PR DESCRIPTION
Following the conventions I discovered/documented [here](https://daniel.feldroy.com/posts/2023-08-pypi-project-urls-cheatsheet) on the next PyPI release this adds links that make it easier for consumers of this project to see what changes may have occurred.

Thanks for a great project!