### PR TITLE
Add links to make PyPI a better maintainer reference

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,3 +32,8 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry-dynamic-versioning]
 enable = true
+
+[tool.poetry.urls]
+changelog = "https://github.com/lidatong/dataclasses-json/releases"
+documentation = "https://lidatong.github.io/dataclasses-json/"
+issues = "https://github.com/lidatong/dataclasses-json/issues"


### PR DESCRIPTION
Following the conventions I discovered/documented [here](https://daniel.feldroy.com/posts/2023-08-pypi-project-urls-cheatsheet) on the next PyPI release this adds links that make it easier for consumers of this project to see what changes may have occurred.

Thanks for the project!