### PR TITLE
fix mypy error when assigning to dataclass_json_config

### DIFF
--- a/dataclasses_json/api.py
+++ b/dataclasses_json/api.py
@@ -21,7 +21,7 @@ class DataClassJsonMixin(abc.ABC):
 
     As with other ABCs, it should not be instantiated directly.
     """
-    dataclass_json_config = None
+    dataclass_json_config: Optional[dict] = None
 
     def to_json(self,
                 *,


### PR DESCRIPTION
Given our code:

```python
from dataclasses import dataclass
from dataclasses_json import DataClassJsonMixin, LetterCase, config

camelCaseConfig = config(letter_case=LetterCase.CAMEL)["dataclasses_json"]


@dataclass()
class MyDataStructure(DataClassJsonMixin):
    dataclass_json_config = camelCaseConfig

    name: str
```

Running mypy yields the following error:

> error: Incompatible types in assignment (expression has type "dict[Any, Any]", base class "DataClassJsonMixin" defined the type as "None")  [assignment]

The type is "defined as None" because no explicit type is given when initializing the variable. 

This PR provides the correct explicit type for `dataclass_json_config`.