### PR TITLE
fix: allow using CatchAll with postponed evaluation of annotations

### DIFF
--- a/dataclasses_json/undefined.py
+++ b/dataclasses_json/undefined.py
@@ -2,8 +2,9 @@ import abc
 import dataclasses
 import functools
 import inspect
+import sys
 from dataclasses import Field, fields
-from typing import Any, Callable, Dict, Optional, Tuple, Union, Type
+from typing import Any, Callable, Dict, Optional, Tuple, Union, Type, get_type_hints
 from enum import Enum
 
 from marshmallow.exceptions import ValidationError  # type: ignore
@@ -246,8 +247,10 @@ class _CatchAllUndefinedParameters(_UndefinedParameterAction):
 
     @staticmethod
     def _get_catch_all_field(cls) -> Field:
+        cls_globals = vars(sys.modules[cls.__module__])
+        types = get_type_hints(cls, globalns=cls_globals)
         catch_all_fields = list(
-            filter(lambda f: f.type == Optional[CatchAllVar], fields(cls)))
+            filter(lambda f: types[f.name] == Optional[CatchAllVar], fields(cls)))
         number_of_catch_all_fields = len(catch_all_fields)
         if number_of_catch_all_fields == 0:
             raise UndefinedParameterError(


### PR DESCRIPTION
This PR addresses Issue #382

@george-zubrienko I understand that you had not planned to tackle this issue before v1 and am aware of the discussions in Issue #458 as well.

As mentioned by @USSX-Hares, there's a possibility PEP-649 ends up superseding PEP-563. However, [a decision still has to be made](https://mail.python.org/archives/list/python-dev@python.org/message/VIZEBX5EYMSYIJNDBF6DMUMZOCWHARSO/)

In the meantime, the inability to use `CatchAll` is a major blocker for the full adoption of `dataclasses_json` in my team as we
rely heavily on type hints and have no other option but to postpone their evaluation through `from __future__ import annotations`.

The proposed solution relies on `typing.get_type_hints()` (as suggested by @estyxx) instead of `field.type` (whose type depends on whether or not `from __future__ import annotations` is used)

The globals associated with the decorated class `cls : Type[A]` are gathered using `vars(sys.modules[cls.__module__])`, as recommended in the [PEP563- Resolving Type Hints at Runtime](https://peps.python.org/pep-0563/#resolving-type-hints-at-runtime) section.