### PR TITLE
Fix snakecase converter for multi-numeric strings

### DIFF
--- a/dataclasses_json/stringcase.py
+++ b/dataclasses_json/stringcase.py
@@ -95,10 +95,14 @@ def snakecase(string):
     string = re.sub(r"[\-\.\s]", '_', str(string))
     if not string:
         return string
-    return (uplowcase(string[0], 'low')
-            + re.sub(r"[A-Z0-9]",
-                     lambda matched: '_' + uplowcase(matched.group(0), 'low'),
-                     string[1:]))
+    return uplowcase(
+        '_'.join(
+            re.sub(
+                '([A-Z][a-z]+)', r' \1',
+                re.sub('([A-Z]+)', r' \1', string.replace('-', ' '))
+            ).split()
+        ), 'low'
+    )
 
 
 def spinalcase(string):


### PR DESCRIPTION
Resolves https://github.com/lidatong/dataclasses-json/issues/516

Change to the SnakeCase letter converter to give more consistent behavior for strings containing multiple numeric characters in sequence. For instance:

>>print(old_snakecase('Alice'), new_snakecase('Alice'))
alice alice

>>print(old_snakecase('Alice123'), new_snakecase('Alice123'))
alice_1_2_3 alice123

>>print(old_snakecase('AliceBob123'), new_snakecase('AliceBob123'))
alice_bob_1_2_3 alice_bob123