### PR TITLE
improvements of subclasses and jsonization time by add two options in global_config

### DIFF
--- a/dataclasses_json/cfg.py
+++ b/dataclasses_json/cfg.py
@@ -30,6 +30,8 @@ class _GlobalConfig:
             Union[type, Optional[type]],
             MarshmallowField
         ] = {}
+        self.enable_cache = False
+        self.include_class_info = False
         # self._json_module = json
 
     # TODO: #180

--- a/include_class_info.ipynb
+++ b/include_class_info.ipynb
@@ -1,0 +1,523 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 1. include class info in the json result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataclasses import dataclass,field\n",
+    "from typing import Set, Optional\n",
+    "\n",
+    "from dataclasses_json import dataclass_json,global_config\n",
+    "\n",
+    "\n",
+    "@dataclass_json\n",
+    "@dataclass\n",
+    "class Animal:\n",
+    "    id: int = 0\n",
+    "    health: int = 100\n",
+    "\n",
+    "\n",
+    "@dataclass_json\n",
+    "@dataclass\n",
+    "class Cat(Animal):\n",
+    "    age: int = 1\n",
+    "\n",
+    "@dataclass_json\n",
+    "@dataclass\n",
+    "class Dog(Animal):\n",
+    "    age: int = 1\n",
+    "\n",
+    "@dataclass_json\n",
+    "@dataclass\n",
+    "class PetCat(Cat):\n",
+    "    name: str = ''\n",
+    "\n",
+    "@dataclass_json\n",
+    "@dataclass\n",
+    "class Person:\n",
+    "    name:str = 'zyx'\n",
+    "    animals: list[Animal] = field(default_factory=lambda:[])\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'name': 'zyx',\n",
+       " 'animals': [{'id': 0, 'health': 100},\n",
+       "  {'id': 0, 'health': 100, 'age': 1},\n",
+       "  {'id': 0, 'health': 100, 'age': 1, 'name': ''}]}"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "p1=Person(animals=[Animal(),Cat(),PetCat()])\n",
+    "p1.to_dict()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'name': 'zyx',\n",
+       " 'animals': [{'id': 0, 'health': 100},\n",
+       "  {'id': 0, 'health': 100},\n",
+       "  {'id': 0, 'health': 100}]}"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "p2 = Person.from_dict(p1.to_dict())\n",
+    "p2.to_dict()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "some fields are missing!\n",
+    "\n",
+    "to solve this, we need to include class info into the result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'__module__': '__main__',\n",
+       " '__name__': 'Person',\n",
+       " 'name': 'zyx',\n",
+       " 'animals': [{'__module__': '__main__',\n",
+       "   '__name__': 'Animal',\n",
+       "   'id': 0,\n",
+       "   'health': 100},\n",
+       "  {'__module__': '__main__',\n",
+       "   '__name__': 'Cat',\n",
+       "   'id': 0,\n",
+       "   'health': 100,\n",
+       "   'age': 1},\n",
+       "  {'__module__': '__main__',\n",
+       "   '__name__': 'PetCat',\n",
+       "   'id': 0,\n",
+       "   'health': 100,\n",
+       "   'age': 1,\n",
+       "   'name': ''}]}"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "global_config.include_class_info=True\n",
+    "p1.to_dict()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'name': 'zyx',\n",
+       " 'animals': [{'id': 0, 'health': 100},\n",
+       "  {'id': 0, 'health': 100, 'age': 1},\n",
+       "  {'id': 0, 'health': 100, 'age': 1, 'name': ''}]}"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "p2 = Person.from_dict(p1.to_dict())\n",
+    "global_config.include_class_info=False\n",
+    "p2.to_dict()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "now the fields are all restored!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 2. use cache to save time"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "if i have thousands of objects to jsonize, the code will waste much time on get dataclass info, which will not change however in the process of jsonization "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Wed Feb 28 21:25:23 2024    profile_stats\n",
+      "\n",
+      "         11802740 function calls (10302726 primitive calls) in 6.541 seconds\n",
+      "\n",
+      "   Ordered by: cumulative time\n",
+      "\n",
+      "   ncalls  tottime  percall  cumtime  percall filename:lineno(function)\n",
+      "        2    0.000    0.000    6.541    3.270 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\site-packages\\IPython\\core\\interactiveshell.py:3541(run_code)\n",
+      "        2    0.000    0.000    6.541    3.270 {built-in method builtins.exec}\n",
+      "        1    0.000    0.000    6.541    6.541 C:\\Users\\ZYX\\AppData\\Local\\Temp\\ipykernel_21292\\461415860.py:1(<module>)\n",
+      "        1    0.004    0.004    6.541    6.541 d:\\workspace\\dataclasses-json\\dataclasses_json\\api.py:26(to_json)\n",
+      "        1    0.000    0.000    6.488    6.488 d:\\workspace\\dataclasses-json\\dataclasses_json\\api.py:72(to_dict)\n",
+      " 300003/1    0.772    0.000    6.488    6.488 d:\\workspace\\dataclasses-json\\dataclasses_json\\core.py:429(_asdict)\n",
+      "   100001    0.057    0.000    6.462    0.000 d:\\workspace\\dataclasses-json\\dataclasses_json\\core.py:459(<genexpr>)\n",
+      "700007/300003    0.361    0.000    3.900    0.000 d:\\workspace\\dataclasses-json\\dataclasses_json\\utils.py:14(wrapper)\n",
+      "   200002    1.658    0.000    3.450    0.000 d:\\workspace\\dataclasses-json\\dataclasses_json\\core.py:60(_user_overrides_or_exts)\n",
+      "   500005    0.156    0.000    1.349    0.000 d:\\workspace\\dataclasses-json\\dataclasses_json\\core.py:36(_cached_fields)\n",
+      "   500005    0.808    0.000    1.192    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\dataclasses.py:1269(fields)\n",
+      "1500321/700313    0.349    0.000    1.065    0.000 {built-in method builtins.isinstance}\n",
+      "   400004    0.167    0.000    0.827    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\typing.py:1175(__instancecheck__)\n",
+      "   400004    0.202    0.000    0.660    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\typing.py:1446(__subclasscheck__)\n",
+      "   400004    0.148    0.000    0.348    0.000 {built-in method builtins.issubclass}\n",
+      "   300003    0.160    0.000    0.266    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\dataclasses.py:1292(is_dataclass)\n",
+      "   100001    0.071    0.000    0.227    0.000 d:\\workspace\\dataclasses-json\\dataclasses_json\\utils.py:203(_handle_undefined_parameters_safe)\n",
+      "   400004    0.113    0.000    0.215    0.000 <string>:1(<lambda>)\n",
+      "  1500015    0.205    0.000    0.205    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\dataclasses.py:1284(<genexpr>)\n",
+      "   400004    0.091    0.000    0.199    0.000 <frozen abc>:121(__subclasscheck__)\n",
+      "   800008    0.197    0.000    0.197    0.000 {method 'update' of 'dict' objects}\n",
+      "   100001    0.142    0.000    0.164    0.000 d:\\workspace\\dataclasses-json\\dataclasses_json\\core.py:109(_encode_overrides)\n",
+      "   100001    0.131    0.000    0.131    0.000 d:\\workspace\\dataclasses-json\\dataclasses_json\\utils.py:189(_undefined_parameter_action_safe)\n",
+      "   400004    0.116    0.000    0.116    0.000 {method 'get' of 'mappingproxy' objects}\n",
+      "   700011    0.115    0.000    0.115    0.000 {built-in method builtins.getattr}\n",
+      "   400004    0.108    0.000    0.108    0.000 {built-in method _abc._abc_subclasscheck}\n",
+      "   500307    0.108    0.000    0.108    0.000 {method 'values' of 'dict' objects}\n",
+      "   400004    0.102    0.000    0.102    0.000 {built-in method __new__ of type object at 0x00007FFC09F2B9B0}\n",
+      "   200002    0.051    0.000    0.051    0.000 {method 'append' of 'list' objects}\n",
+      "        1    0.000    0.000    0.048    0.048 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\json\\__init__.py:183(dumps)\n",
+      "        1    0.000    0.000    0.048    0.048 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\json\\encoder.py:183(encode)\n",
+      "        1    0.048    0.048    0.048    0.048 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\json\\encoder.py:205(iterencode)\n",
+      "   300003    0.046    0.000    0.046    0.000 {built-in method builtins.hasattr}\n",
+      "   100001    0.025    0.000    0.025    0.000 {method 'lower' of 'str' objects}\n",
+      "   100001    0.023    0.000    0.023    0.000 {method 'items' of 'dict' objects}\n",
+      "      302    0.002    0.000    0.004    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\site-packages\\ipykernel\\ipkernel.py:770(_clean_thread_parent_frames)\n",
+      "      151    0.001    0.000    0.001    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\threading.py:1533(enumerate)\n",
+      "      755    0.001    0.000    0.001    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\threading.py:1196(ident)\n",
+      "      604    0.000    0.000    0.000    0.000 {method 'keys' of 'dict' objects}\n",
+      "        2    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\codeop.py:121(__call__)\n",
+      "        2    0.000    0.000    0.000    0.000 {built-in method builtins.compile}\n",
+      "        1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}\n",
+      "      151    0.000    0.000    0.000    0.000 {method '__exit__' of '_thread.RLock' objects}\n",
+      "        2    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\contextlib.py:299(helper)\n",
+      "        2    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\site-packages\\traitlets\\traitlets.py:676(__get__)\n",
+      "        4    0.000    0.000    0.000    0.000 {built-in method builtins.next}\n",
+      "        2    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\contextlib.py:104(__init__)\n",
+      "        2    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\contextlib.py:141(__exit__)\n",
+      "        2    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\contextlib.py:132(__enter__)\n",
+      "        2    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\site-packages\\traitlets\\traitlets.py:629(get)\n",
+      "        4    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\site-packages\\IPython\\core\\compilerop.py:180(extra_flags)\n",
+      "        1    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\json\\encoder.py:105(__init__)\n",
+      "        2    0.000    0.000    0.000    0.000 {method 'get' of 'dict' objects}\n",
+      "        2    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\site-packages\\IPython\\core\\interactiveshell.py:3493(compare)\n",
+      "        2    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\site-packages\\IPython\\core\\interactiveshell.py:1277(user_global_ns)\n",
+      "        1    0.000    0.000    0.000    0.000 {method 'join' of 'str' objects}\n",
+      "        4    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\typing.py:2132(cast)\n",
+      "\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<pstats.Stats at 0x22344ab74a0>"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import cProfile\n",
+    "import pstats\n",
+    "global_config.enable_cache=False\n",
+    "p3 = Person(animals=[Animal() for _ in range(100000)])\n",
+    "\n",
+    "# Create a cProfile object\n",
+    "pr = cProfile.Profile()\n",
+    "\n",
+    "# Enable profiling\n",
+    "pr.enable()\n",
+    "\n",
+    "# Run your code\n",
+    "result_without_cache = p3.to_json()\n",
+    "\n",
+    "# Disable profiling\n",
+    "pr.disable()\n",
+    "\n",
+    "# Save the stats to a file\n",
+    "pr.dump_stats('profile_stats')\n",
+    "\n",
+    "# Open the saved stats file in Jupyter Notebook\n",
+    "stats = pstats.Stats('profile_stats')\n",
+    "stats.sort_stats('cumulative')\n",
+    "stats.print_stats()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Wed Feb 28 21:26:30 2024    profile_stats\n",
+      "\n",
+      "         5702755 function calls (4602444 primitive calls) in 2.713 seconds\n",
+      "\n",
+      "   Ordered by: cumulative time\n",
+      "\n",
+      "   ncalls  tottime  percall  cumtime  percall filename:lineno(function)\n",
+      "   100001    0.041    0.000    2.664    0.000 d:\\workspace\\dataclasses-json\\dataclasses_json\\core.py:459(<genexpr>)\n",
+      "1500355/700052    0.493    0.000    1.168    0.000 {built-in method builtins.isinstance}\n",
+      "400006/400004    0.158    0.000    0.783    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\typing.py:1175(__instancecheck__)\n",
+      "400006/400005    0.191    0.000    0.625    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\typing.py:1446(__subclasscheck__)\n",
+      "400006/400005    0.141    0.000    0.327    0.000 {built-in method builtins.issubclass}\n",
+      "   300003    0.147    0.000    0.241    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\dataclasses.py:1292(is_dataclass)\n",
+      "   100001    0.066    0.000    0.208    0.000 d:\\workspace\\dataclasses-json\\dataclasses_json\\utils.py:203(_handle_undefined_parameters_safe)\n",
+      "400006/400005    0.085    0.000    0.186    0.000 <frozen abc>:121(__subclasscheck__)\n",
+      "   100001    0.130    0.000    0.153    0.000 d:\\workspace\\dataclasses-json\\dataclasses_json\\core.py:109(_encode_overrides)\n",
+      "   300003    0.129    0.000    0.129    0.000 d:\\workspace\\dataclasses-json\\dataclasses_json\\utils.py:14(wrapper)\n",
+      "   100001    0.118    0.000    0.118    0.000 d:\\workspace\\dataclasses-json\\dataclasses_json\\utils.py:189(_undefined_parameter_action_safe)\n",
+      "   400006    0.098    0.000    0.098    0.000 {built-in method _abc._abc_subclasscheck}\n",
+      "   200002    0.048    0.000    0.048    0.000 {method 'append' of 'list' objects}\n",
+      "        1    0.000    0.000    0.048    0.048 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\json\\__init__.py:183(dumps)\n",
+      "        1    0.000    0.000    0.047    0.047 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\json\\encoder.py:183(encode)\n",
+      "        1    0.047    0.047    0.047    0.047 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\json\\encoder.py:205(iterencode)\n",
+      "   200009    0.043    0.000    0.043    0.000 {built-in method builtins.getattr}\n",
+      "   300006    0.043    0.000    0.043    0.000 {built-in method builtins.hasattr}\n",
+      "   100001    0.024    0.000    0.024    0.000 {method 'lower' of 'str' objects}\n",
+      "   100001    0.022    0.000    0.022    0.000 {method 'items' of 'dict' objects}\n",
+      "      286    0.002    0.000    0.004    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\site-packages\\ipykernel\\ipkernel.py:770(_clean_thread_parent_frames)\n",
+      "      143    0.001    0.000    0.001    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\threading.py:1533(enumerate)\n",
+      "      715    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\threading.py:1196(ident)\n",
+      "        1    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\asyncio\\base_events.py:1908(_run_once)\n",
+      "       12    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\site-packages\\zmq\\sugar\\socket.py:621(send)\n",
+      "        2    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\site-packages\\zmq\\eventloop\\zmqstream.py:687(_rebuild_io_state)\n",
+      "        1    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\asyncio\\events.py:86(_run)\n",
+      "        1    0.000    0.000    0.000    0.000 {method 'run' of '_contextvars.Context' objects}\n",
+      "        1    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\site-packages\\tornado\\ioloop.py:730(_run_callback)\n",
+      "        1    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\site-packages\\zmq\\eventloop\\zmqstream.py:718(<lambda>)\n",
+      "        1    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\site-packages\\zmq\\eventloop\\zmqstream.py:607(_handle_events)\n",
+      "        1    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\site-packages\\ipykernel\\iostream.py:276(<lambda>)\n",
+      "        1    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\site-packages\\ipykernel\\iostream.py:278(_really_send)\n",
+      "       12    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\enum.py:1531(__or__)\n",
+      "        1    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\site-packages\\zmq\\sugar\\socket.py:698(send_multipart)\n",
+      "        2    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\site-packages\\zmq\\eventloop\\zmqstream.py:710(_update_handler)\n",
+      "        3    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\site-packages\\zmq\\sugar\\attrsettr.py:42(__getattr__)\n",
+      "      572    0.000    0.000    0.000    0.000 {method 'keys' of 'dict' objects}\n",
+      "        2    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\codeop.py:121(__call__)\n",
+      "        3    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\site-packages\\zmq\\sugar\\attrsettr.py:65(_get_attr_opt)\n",
+      "        2    0.000    0.000    0.000    0.000 {built-in method builtins.compile}\n",
+      "       21    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\enum.py:713(__call__)\n",
+      "        1    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\site-packages\\zmq\\eventloop\\zmqstream.py:648(_handle_recv)\n",
+      "      286    0.000    0.000    0.000    0.000 {method 'values' of 'dict' objects}\n",
+      "        1    0.000    0.000    0.000    0.000 C:\\Users\\ZYX\\AppData\\Local\\Temp\\ipykernel_21292\\1644171530.py:1(<module>)\n",
+      "        1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}\n",
+      "        1    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\selectors.py:319(select)\n",
+      "        5    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\enum.py:1541(__and__)\n",
+      "      143    0.000    0.000    0.000    0.000 {method '__exit__' of '_thread.RLock' objects}\n",
+      "        1    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\site-packages\\tornado\\platform\\asyncio.py:215(add_callback)\n",
+      "        1    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\site-packages\\zmq\\sugar\\socket.py:777(recv_multipart)\n",
+      "        2    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\site-packages\\zmq\\eventloop\\zmqstream.py:566(sending)\n",
+      "        1    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\selectors.py:313(_select)\n",
+      "       21    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\enum.py:1116(__new__)\n",
+      "        2    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\queue.py:97(empty)\n",
+      "        1    0.000    0.000    0.000    0.000 {built-in method select.select}\n",
+      "        1    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\asyncio\\base_events.py:783(call_soon)\n",
+      "        1    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\asyncio\\base_events.py:812(_call_soon)\n",
+      "        1    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\site-packages\\zmq\\eventloop\\zmqstream.py:580(_run_callback)\n",
+      "        3    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\typing.py:378(inner)\n",
+      "        3    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:1390(_handle_fromlist)\n",
+      "        2    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\contextlib.py:299(helper)\n",
+      "        2    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\queue.py:209(_qsize)\n",
+      "        2    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\asyncio\\base_events.py:732(time)\n",
+      "        1    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\asyncio\\events.py:36(__init__)\n",
+      "        1    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\site-packages\\ipykernel\\iostream.py:216(_check_mp_mode)\n",
+      "        4    0.000    0.000    0.000    0.000 {built-in method builtins.next}\n",
+      "        2    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\contextlib.py:132(__enter__)\n",
+      "        2    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\site-packages\\traitlets\\traitlets.py:676(__get__)\n",
+      "        2    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\contextlib.py:141(__exit__)\n",
+      "        2    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\contextlib.py:104(__init__)\n",
+      "        1    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\site-packages\\ipykernel\\iostream.py:213(_is_master_process)\n",
+      "        3    0.000    0.000    0.000    0.000 {built-in method builtins.max}\n",
+      "        2    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\typing.py:1239(__hash__)\n",
+      "        6    0.000    0.000    0.000    0.000 {built-in method builtins.len}\n",
+      "        1    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\site-packages\\ipykernel\\iostream.py:157(_handle_event)\n",
+      "        2    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\site-packages\\traitlets\\traitlets.py:629(get)\n",
+      "        3    0.000    0.000    0.000    0.000 {method 'upper' of 'str' objects}\n",
+      "        4    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\site-packages\\IPython\\core\\compilerop.py:180(extra_flags)\n",
+      "        2    0.000    0.000    0.000    0.000 {method 'popleft' of 'collections.deque' objects}\n",
+      "        2    0.000    0.000    0.000    0.000 {built-in method time.monotonic}\n",
+      "        1    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\json\\encoder.py:105(__init__)\n",
+      "        1    0.000    0.000    0.000    0.000 {built-in method _asyncio.get_running_loop}\n",
+      "        2    0.000    0.000    0.000    0.000 {method 'get' of 'dict' objects}\n",
+      "        1    0.000    0.000    0.000    0.000 {method 'append' of 'collections.deque' objects}\n",
+      "        2    0.000    0.000    0.000    0.000 {method '__exit__' of '_thread.lock' objects}\n",
+      "        3    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\site-packages\\zmq\\eventloop\\zmqstream.py:562(receiving)\n",
+      "        1    0.000    0.000    0.000    0.000 {built-in method _contextvars.copy_context}\n",
+      "        1    0.000    0.000    0.000    0.000 {built-in method nt.getpid}\n",
+      "        1    0.000    0.000    0.000    0.000 {built-in method builtins.min}\n",
+      "        2    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\site-packages\\IPython\\core\\interactiveshell.py:3493(compare)\n",
+      "        1    0.000    0.000    0.000    0.000 {method 'join' of 'str' objects}\n",
+      "        2    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\site-packages\\IPython\\core\\interactiveshell.py:1277(user_global_ns)\n",
+      "        2    0.000    0.000    0.000    0.000 {built-in method builtins.hash}\n",
+      "        1    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\site-packages\\ipykernel\\iostream.py:255(closed)\n",
+      "        5    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\typing.py:2132(cast)\n",
+      "        1    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\asyncio\\selector_events.py:750(_process_events)\n",
+      "        1    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\asyncio\\base_events.py:538(_check_closed)\n",
+      "        1    0.000    0.000    0.000    0.000 c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\asyncio\\base_events.py:2003(get_debug)\n",
+      "      1/0    0.000    0.000    0.000          c:\\Users\\ZYX\\miniconda3\\envs\\dsj\\Lib\\site-packages\\IPython\\core\\interactiveshell.py:3541(run_code)\n",
+      " 300001/0    0.684    0.000    0.000          d:\\workspace\\dataclasses-json\\dataclasses_json\\core.py:429(_asdict)\n",
+      "      1/0    0.000    0.000    0.000          {built-in method builtins.exec}\n",
+      "\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<pstats.Stats at 0x22344a734d0>"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import cProfile\n",
+    "import pstats\n",
+    "global_config.enable_cache=True\n",
+    "p3 = Person(animals=[Animal() for _ in range(100000)])\n",
+    "\n",
+    "# Create a cProfile object\n",
+    "pr = cProfile.Profile()\n",
+    "\n",
+    "# Enable profiling\n",
+    "pr.enable()\n",
+    "\n",
+    "# Run your code\n",
+    "result_with_cache = p3.to_json()\n",
+    "\n",
+    "# Disable profiling\n",
+    "pr.disable()\n",
+    "\n",
+    "# Save the stats to a file\n",
+    "pr.dump_stats('profile_stats')\n",
+    "\n",
+    "# Open the saved stats file in Jupyter Notebook\n",
+    "stats = pstats.Stats('profile_stats')\n",
+    "stats.sort_stats('cumulative')\n",
+    "stats.print_stats()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The improvement in program speed is huge, from 6.6s to 2.5s in my laptop\n",
+    "\n",
+    "now let's check if the results are the same"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "result_with_cache==result_without_cache"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "dsj",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
The two contributions of the pr are as follows: 
1. add class info to restore subclasses from json, can be enabled by set  global_config.include_class_info = True
2. save time by cache the result of type checking, can be enabled by set  global_config.enable_cache = True

to see detailed usage and comparation, you can open [the jupyter notebook file](https://github.com/democrazyx/dataclasses-json/blob/zyx/include_class_info.ipynb)

the following code is derived from the ipynb file

```python
# %% [markdown]
# # 1. include class info in the json result

# %%
from dataclasses import dataclass,field
from typing import Set, Optional

from dataclasses_json import dataclass_json,global_config


@dataclass_json
@dataclass
class Animal:
    id: int = 0
    health: int = 100


@dataclass_json
@dataclass
class Cat(Animal):
    age: int = 1

@dataclass_json
@dataclass
class Dog(Animal):
    age: int = 1

@dataclass_json
@dataclass
class PetCat(Cat):
    name: str = ''

@dataclass_json
@dataclass
class Person:
    name:str = 'zyx'
    animals: list[Animal] = field(default_factory=lambda:[])


# %%
p1=Person(animals=[Animal(),Cat(),PetCat()])
p1.to_dict()

# %%
p2 = Person.from_dict(p1.to_dict())
p2.to_dict()

# %% [markdown]
# some fields are missing!
# 
# to solve this, we need to include class info into the result

# %%
global_config.include_class_info=True
p1.to_dict()

# %%
p2 = Person.from_dict(p1.to_dict())
global_config.include_class_info=False
p2.to_dict()

# %% [markdown]
# now the fields are all restored!

# %% [markdown]
# # 2. use cache to save time

# %% [markdown]
# if i have thousands of objects to jsonize, the code will waste much time on get dataclass info, which will not change however in the process of jsonization 

# %%
import cProfile
import pstats
global_config.enable_cache=False
p3 = Person(animals=[Animal() for _ in range(100000)])

pr = cProfile.Profile()
pr.enable()
result_without_cache = p3.to_json()
pr.disable()
pr.dump_stats('profile_stats1')
stats = pstats.Stats('profile_stats1')
stats.sort_stats('cumulative')
stats.print_stats()

# %%
import cProfile
import pstats
global_config.enable_cache=True
p3 = Person(animals=[Animal() for _ in range(100000)])

pr = cProfile.Profile()
pr.enable()
result_with_cache = p3.to_json()
pr.disable()
pr.dump_stats('profile_stats2')
stats = pstats.Stats('profile_stats2')
stats.sort_stats('cumulative')
stats.print_stats()

# %% [markdown]
# The improvement in program speed is huge, from 6.6s to 2.5s in my laptop
# 
# now let's check if the results are the same

# %%
result_with_cache==result_without_cache


```