### PR TITLE
fix: apply global config globally

### DIFF
--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -234,8 +234,7 @@ def _decode_type(type_, value, infer_missing):
         return _decode_dataclass(type_, value, infer_missing)
     if _is_supported_generic(type_):
         return _decode_generic(type_, value, infer_missing)
-    else:
-        return _support_extended_types(type_, value)
+    return _support_extended_types(type_, value)
 
 
 def _support_extended_types(field_type, field_value):

--- a/tests/test_global_config.py
+++ b/tests/test_global_config.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import List, Optional
 
 from dataclasses_json import dataclass_json
 from datetime import date
@@ -19,6 +20,18 @@ class PersonWithBirthday:
     birthday: date
 
 
+@dataclass_json
+@dataclass
+class HistoricalEvents:
+    dates: List[date]
+
+
+@dataclass_json
+@dataclass
+class PackageDelivery:
+    date: Optional[date]
+
+
 class TestGlobalConfig:
     def test_encoder_override(self):
         dataclasses_json.cfg.global_config.encoders[str] = lambda s: s[::-1]
@@ -30,3 +43,23 @@ class TestGlobalConfig:
         assert PersonWithBirthday("Kobe Bryant", date(1978, 8, 23)).to_json() \
                == '{"name": "Kobe Bryant", "birthday": "1978-08-23"}'
         dataclasses_json.cfg.global_config.encoders = {}
+
+    def test_encoder_and_decoder_extension_in_collections(self):
+        dataclasses_json.cfg.global_config.encoders[date] = date.isoformat
+        dataclasses_json.cfg.global_config.decoders[date] = date.fromisoformat
+        historical_events = HistoricalEvents([date(1918, 11, 11), date(1945, 5, 8)])
+        expected_json = '{"dates": ["1918-11-11", "1945-05-08"]}'
+        assert historical_events.to_json() == expected_json
+        assert HistoricalEvents.from_json(expected_json) == historical_events
+        dataclasses_json.cfg.global_config.encoders = {}
+        dataclasses_json.cfg.global_config.decoders = {}
+
+    def test_encoder_and_decoder_extension_in_union(self):
+        dataclasses_json.cfg.global_config.encoders[date] = date.isoformat
+        dataclasses_json.cfg.global_config.decoders[date] = date.fromisoformat
+        package_delivery = PackageDelivery(date(2023, 1, 1))
+        expected_json = '{"date": "2023-01-01"}'
+        assert package_delivery.to_json() == expected_json
+        assert PackageDelivery.from_json(expected_json) == package_delivery
+        dataclasses_json.cfg.global_config.encoders = {}
+        dataclasses_json.cfg.global_config.decoders = {}

--- a/tests/test_union.py
+++ b/tests/test_union.py
@@ -276,3 +276,11 @@ def test_deserialize_with_mismatched_field_types():
     obj = s.loads(json)
     assert obj.event is not None
     assert obj.event.data == "Hello world!"
+
+
+def test_deserialize_with_mismatched_field_types():
+    json = '{"event": {"data": "Hello world!"} }'
+    s = C16.schema()
+    obj = s.loads(json)
+    assert obj.event is not None
+    assert obj.event.data == "Hello world!"


### PR DESCRIPTION
Use the encoder/decoder registered in the global configuration 