### PR TITLE
Warn about buggy type resolution

### DIFF
--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -378,9 +378,11 @@ def _decode_items(type_args, xs, infer_missing):
     hence the check of `is_dataclass(vs)`
     """
     def handle_pep0673(pre_0673_hint: str) -> Union[Type, str]:
-        for module in sys.modules:
-            maybe_resolved = getattr(sys.modules[module], type_args, None)
-            if maybe_resolved:
+        for module in sys.modules.values():
+            if hasattr(module, type_args):
+                maybe_resolved = getattr(module, type_args)
+                warnings.warn(f"Assuming hint {pre_0673_hint} resolves to {maybe_resolved} "
+                              "This is not necessarily the value that is in-scope.")
                 return maybe_resolved
 
         warnings.warn(f"Could not resolve self-reference for type {pre_0673_hint}, "

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,35 @@
+from dataclasses import dataclass
+import pytest
+from typing import Optional, Set
+
+from dataclasses_json import dataclass_json
+
+
+@dataclass_json
+@dataclass
+class Config:
+    options: list["Option"]
+
+@dataclass_json
+@dataclass
+class Option:
+    label: str
+
+@dataclass_json
+@dataclass
+class ConfigWithoutStringOptions:
+    options: list[Option]
+
+
+
+
+class TestWarning:
+    def test_warns_about_nondeterministic_resolution(self):
+        with pytest.warns(UserWarning, match="Assuming hint Option resolves to .*"):
+            config = Config.from_dict({"options": [{"label": "scope"}]})
+        assert config.to_json() == '{"options": [{"label": "scope"}]}'
+
+
+    @pytest.mark.filterwarnings("error")
+    def test_plain_type_hints_resolve_correctly(self):
+        ConfigWithoutStringOptions.from_dict({"options": [{"label": "scope"}]})

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -27,7 +27,10 @@ if sys.version_info >= (3, 9):
 
 
 
-@pytest.mark.skipif(sys.version_info < (3, 9), reason="requires generic types for bug")
+@pytest.mark.skipif(
+    not ((3, 9) < sys.version_info < (3, 11)),
+    reason="syntax only valid on Py3.9, but bug disappears after Python 3.11",
+)
 class TestWarning:
     def test_warns_about_nondeterministic_resolution(self):
         with pytest.warns(UserWarning, match="Assuming hint Option resolves to .*"):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,28 +1,33 @@
 from dataclasses import dataclass
 import pytest
-from typing import Optional, Set
+from typing import Optional, Set, List
 
 from dataclasses_json import dataclass_json
+import sys
 
 
-@dataclass_json
-@dataclass
-class Config:
-    options: list["Option"]
+# This test exists *only* to demonstrate a bug on Python 3.9+
+# It uses syntax that is not valid on earlier versions of Python!
+if sys.version_info >= (3, 9):
+    @dataclass_json
+    @dataclass
+    class Config:
+        options: list["Option"]
 
-@dataclass_json
-@dataclass
-class Option:
-    label: str
+    @dataclass_json
+    @dataclass
+    class Option:
+        label: str
 
-@dataclass_json
-@dataclass
-class ConfigWithoutStringOptions:
-    options: list[Option]
-
-
+    @dataclass_json
+    @dataclass
+    class ConfigWithoutStringOptions:
+        options: list[Option]
 
 
+
+
+@pytest.mark.skipif(sys.version_info < (3, 9), reason="requires generic types for bug")
 class TestWarning:
     def test_warns_about_nondeterministic_resolution(self):
         with pytest.warns(UserWarning, match="Assuming hint Option resolves to .*"):


### PR DESCRIPTION
This type annotation resolution is a flawed implementation -- ideally a
proper fix can come later, but for now it's worth warning about the
present behavior.

`dataclasses-json` does not behave correctly when using string-style
annotations (a frequent tactic for annotating types that have not yet
been defined at that point in the file).

The core problem comes from the assumption that type annotations in a
module will match `sys.modules()` -- `maybe_resolved` will frequently
resolve to a different value than a typechecker would!

A short example of the error
============================

`example_types.py`:
```python
from dataclasses import dataclass

from dataclasses_json import dataclass_json

@dataclass_json
@dataclass
class Config:
    options: list["Option"]

@dataclass_json
@dataclass
class Option:
    label: str
```

Expected behavior
-----------------
`_decode_items` correctly identifies `Option` as coming from
`example_types`:

```python
>>> from example_types import Config
>>> print(Config.from_dict({"options": [{"label": "repro"}]}).options)
[Option(label='repro')]
```

Unexpected behavior
-------------------
`_decode_items()` incorrectly identifies `"Option"` as from a third
party module that is not in scope at time of annotation:

`repro.py`:
```python
import click.parser  # Has `Option`
from example_types import Config

print(Config.from_dict({"options": [{"label": "repro"}]}).options)
```

```bash
$ python3.10 repro.py
[{'label': 'repro'}]
```

Related fix -- truthiness
=========================
The conditional `if maybe_resolved` is meant to handle the case of an
attribute not being found in the module (it could basically be written
as `if maybe_resolved is not None`). However, that doesn't cover the
case of types that are falsy at runtime!

```python
CustomNoneType = None

values: list['CustomNoneType'] = [None, None]
```

We can just use `hasattr()` instead.