### PR TITLE
feat: support abstract collections

### DIFF
--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -3,6 +3,8 @@ import json
 import sys
 import warnings
 from collections import defaultdict, namedtuple
+from collections.abc import (Collection as ABCCollection, Mapping as ABCMapping, MutableMapping, MutableSequence,
+                             MutableSet, Sequence, Set)
 from dataclasses import (MISSING,
                          fields,
                          is_dataclass  # type: ignore
@@ -10,6 +12,7 @@ from dataclasses import (MISSING,
 from datetime import datetime, timezone
 from decimal import Decimal
 from enum import Enum
+from types import MappingProxyType
 from typing import (Any, Collection, Mapping, Union, get_type_hints,
                     Tuple, TypeVar, Type)
 from uuid import UUID
@@ -31,6 +34,15 @@ Json = Union[dict, list, str, int, float, bool, None]
 
 confs = ['encoder', 'decoder', 'mm_field', 'letter_case', 'exclude']
 FieldOverride = namedtuple('FieldOverride', confs)  # type: ignore
+collections_abc_mapping = MappingProxyType({
+    ABCCollection: tuple,
+    ABCMapping: dict,
+    MutableMapping: dict,
+    MutableSequence: list,
+    MutableSet: set,
+    Sequence: tuple,
+    Set: frozenset,
+})
 
 
 class _ExtendedEncoder(json.JSONEncoder):
@@ -304,11 +316,14 @@ def _decode_generic(type_, value, infer_missing):
 
         # get the constructor if using corresponding generic type in `typing`
         # otherwise fallback on constructing using type_ itself
-        materialize_type = type_
         try:
             materialize_type = _get_type_cons(type_)
         except (TypeError, AttributeError):
-            pass
+            materialize_type = type_
+
+        # map abstract collection to concrete implementation
+        materialize_type = collections_abc_mapping.get(materialize_type, materialize_type)
+
         res = materialize_type(xs)
     elif _is_generic_dataclass(type_):
         origin = _get_type_origin(type_)

--- a/tests/entities.py
+++ b/tests/entities.py
@@ -1,5 +1,6 @@
 import sys
 from collections import deque
+from collections.abc import Mapping, MutableMapping, MutableSequence, MutableSet, Sequence, Set as ABCSet
 from dataclasses import dataclass, field
 from datetime import datetime
 from decimal import Decimal
@@ -388,3 +389,45 @@ class DataClassWithCounter:
 class DataClassWithSelf(DataClassJsonMixin):
     id: str
     ref: Optional['DataClassWithSelf']
+
+
+@dataclass_json
+@dataclass
+class DataClassWithCollection(DataClassJsonMixin):
+    c: Collection[int]
+
+
+@dataclass_json
+@dataclass
+class DataClassWithMapping(DataClassJsonMixin):
+    c: Mapping[str, int]
+
+
+@dataclass_json
+@dataclass
+class DataClassWithMutableMapping(DataClassJsonMixin):
+    c: MutableMapping[str, int]
+
+
+@dataclass_json
+@dataclass
+class DataClassWithMutableSequence(DataClassJsonMixin):
+    c: MutableSequence[int]
+
+
+@dataclass_json
+@dataclass
+class DataClassWithMutableSet(DataClassJsonMixin):
+    c: MutableSet[int]
+
+
+@dataclass_json
+@dataclass
+class DataClassWithSequence(DataClassJsonMixin):
+    c: Sequence[int]
+
+
+@dataclass_json
+@dataclass
+class DataClassWithAbstractSet(DataClassJsonMixin):
+    c: ABCSet[int]

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -1,5 +1,7 @@
 from collections import Counter, deque
 
+import pytest
+
 from tests.entities import (DataClassIntImmutableDefault,
                             DataClassMutableDefaultDict,
                             DataClassMutableDefaultList, DataClassWithDeque,
@@ -20,7 +22,10 @@ from tests.entities import (DataClassIntImmutableDefault,
                             DataClassWithDequeCollections,
                             DataClassWithTuple, DataClassWithTupleUnbound,
                             DataClassWithUnionIntNone, MyCollection,
-                            DataClassWithCounter)
+                            DataClassWithCounter, DataClassWithCollection,
+                            DataClassWithMapping, DataClassWithMutableMapping,
+                            DataClassWithMutableSet, DataClassWithMutableSequence,
+                            DataClassWithSequence, DataClassWithAbstractSet)
 
 
 class TestEncoder:
@@ -244,3 +249,18 @@ class TestDecoder:
     def test_counter(self):
         assert DataClassWithCounter.from_json('{"c": {"f": 1, "o": 2}}') == \
                DataClassWithCounter(c=Counter('foo'))
+
+    @pytest.mark.parametrize(
+        "json_string, expected_instance",
+        [
+            pytest.param('{"c": [1, 2]}', DataClassWithCollection((1, 2)), id="collection"),
+            pytest.param('{"c": [1, 2]}', DataClassWithSequence((1, 2)), id="sequence"),
+            pytest.param('{"c": [1, 2]}', DataClassWithMutableSequence([1, 2]), id="mutable-sequence"),
+            pytest.param('{"c": [1, 2]}', DataClassWithAbstractSet({1, 2}), id="set"),
+            pytest.param('{"c": [1, 2]}', DataClassWithMutableSet({1, 2}), id="mutable-set"),
+            pytest.param('{"c": {"1": 1, "2": 2}}', DataClassWithMapping({"1": 1, "2": 2}), id="mapping"),
+            pytest.param('{"c": {"1": 1, "2": 2}}', DataClassWithMutableMapping({"1": 1, "2": 2}), id="mutable-mapping"),
+       ]
+    )
+    def test_abstract_collections(self, json_string, expected_instance):
+        assert type(expected_instance).from_json(json_string) == expected_instance


### PR DESCRIPTION
Typing with abstract collections rather than concrete implementations typically make for a looser and contract based API.
This PR implements decoding to an abstract collections by selecting an implementation that conforms to the abstraction. 