### PR TITLE
Propagate exclude to marshmallow

### DIFF
--- a/dataclasses_json/mm.py
+++ b/dataclasses_json/mm.py
@@ -376,7 +376,8 @@ def build_schema(cls: typing.Type[A],
     @post_dump(pass_many=True)
     def _exclude_fields(self, data, many, **kwargs):
         def exclude(k, v) -> bool:
-            if f := self.fields.get(k):
+            if self.fields.get(k):
+                f = self.fields[k]
                 if f.metadata.get("dataclasses_json", {}).get(
                     "exclude", lambda x: False
                 )(v):

--- a/tests/test_exclude.py
+++ b/tests/test_exclude.py
@@ -49,3 +49,22 @@ def test_custom_action_excluded():
     dclass = EncodeCustom(public_field="public", sensitive_field="secret")
     encoded = dclass.to_dict()
     assert "sensitive_field" not in encoded
+
+
+def test_marshmallow_exclude_dump():
+    dclass = EncodeExclude(public_field="public", private_field="private")
+    encoded = EncodeExclude.schema().dump(dclass)
+    assert "public_field" in encoded
+    assert "private_field" not in encoded
+
+
+def test_marshmallow_exclude_dumps():
+    dclass = EncodeExclude(public_field="public", private_field="private")
+    encoded = EncodeExclude.schema().dumps(dclass)
+    assert "public_field" in encoded
+    assert "private_field" not in encoded
+
+def test_schema():
+    dclass = EncodeExclude(public_field="public", private_field="private")
+    schema = EncodeExclude.schema()
+    print(schema)


### PR DESCRIPTION
Potential solution for: https://github.com/lidatong/dataclasses-json/issues/369

* Propagate exclude function as metadata on schema field
* Add a post-dump hook to exclude fields as indicated