### PR TITLE
fix: make functions in LetterCase members of the enum

### DIFF
--- a/dataclasses_json/cfg.py
+++ b/dataclasses_json/cfg.py
@@ -48,10 +48,13 @@ global_config = _GlobalConfig()
 
 
 class LetterCase(Enum):
-    CAMEL = camelcase
-    KEBAB = spinalcase
-    SNAKE = snakecase
-    PASCAL = pascalcase
+    CAMEL = functools.partial(camelcase)
+    KEBAB = functools.partial(spinalcase)
+    SNAKE = functools.partial(snakecase)
+    PASCAL = functools.partial(pascalcase)
+
+    def __call__(self, string: str) -> str:
+        return self.value(string)
 
 
 def config(metadata: Optional[dict] = None, *,


### PR DESCRIPTION
Addresses #544

- Wrap functions with `functools.partial` so they're not registered as methods when assigning them to attributes in the `LetterCase` enum
- Implement `LetterCase.__call__` to maintain the current behaviour of being able to call members of the enum without having to use `.value`