### PR TITLE
Improve decoding performance of dataclasses-json

### DIFF
--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -87,7 +87,7 @@ def _user_overrides_or_exts(cls):
         cls_config = {}
 
     overrides = {}
-    for field in fields(cls):
+    for field in cls_fields:
         field_config = {}
         # first apply global overrides or extensions
         field_metadata = global_metadata[field.name]
@@ -350,6 +350,7 @@ def _decode_generic(type_, value, infer_missing):
                     )
     return res
 
+_identity_decoder  = (lambda x: x)
 
 def _decode_dict_keys(key_type, xs, infer_missing):
     """
@@ -364,7 +365,7 @@ def _decode_dict_keys(key_type, xs, infer_missing):
     #   By some reason, "unbound" dicts are counted
     #   as having key type parameter to be TypeVar('KT')
     if key_type is None or key_type == Any or isinstance(key_type, TypeVar):
-        decode_function = key_type = (lambda x: x)
+        decode_function = key_type = _identity_decoder
     # handle a nested python dict that has tuples for keys. E.g. for
     # Dict[Tuple[int], int], key_type will be typing.Tuple[int], but
     # decode_function should be tuple, so map() doesn't break.

--- a/dataclasses_json/utils.py
+++ b/dataclasses_json/utils.py
@@ -153,6 +153,10 @@ def _is_mapping(type_):
 
 
 def _is_collection(type_):
+    if type_ in (list, tuple, dict, set):
+        return True
+    if type_ in (int, float, bool):
+        return False
     return _issubclass_safe(_get_type_origin(type_), Collection)
 
 


### PR DESCRIPTION
We improve performance of decoding by:

* Reducing the number of times `fields(obj)` is calculated
* Adding fast paths for the common types (e.g. int, float, str, ...)
* Avoid repeated creating of the same lambda function

Benchmark:
```
from dataclasses import dataclass
import dataclasses_json
import dataclasses_json.core
import timeit


@dataclasses_json.dataclass_json
@dataclass
class A:
    s : str
    i : int
    b : bool
    d : dict[str, str]
    
a=A('hi', 3, 3.14, {'a': 'dict'})    
j= a.to_json()
a2=A.from_json(j)

print(timeit.timeit('a.to_json()', globals=globals(), number=100_000))
print(timeit.timeit('A.from_json(j)', globals=globals(), number=100_000))
```
Results on master:
```
2.1303018000908196
5.067091099917889
```
This PR:
```
2.1118524000048637
3.4828713997267187
```

