### PR TITLE
feat: support poetry 2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,24 @@
-[tool.poetry]
+[project]
 name = "dataclasses-json"
 version = "0.0.0"
 description = "Easily serialize dataclasses to and from JSON."
-authors = ["Charles Li <charles.dt.li@gmail.com>"]
-maintainers = ['Charles Li <charles.dt.li@gmail.com>', 'Georgiy Zubrienko <gzu@ecco.com>', 'Vitaliy Savitskiy <visa@ecco.com>', 'Matthias Als <mata@ecco.com>']
+authors = [
+    { "name" = "Charles Li", "email" = "charles.dt.li@gmail.com" },
+]
+maintainers = [
+    { "name" = "Charles Li", "email" = "charles.dt.li@gmail.com" },
+    { "name" = "Georgiy Zubrienko", "email" = "gzu@ecco.com" },
+    { "name" = "Vitaliy Savitskiy", "email" = "visa@ecco.com" },
+    { "name" = "Matthias Als", "email" = "mata@ecco.com>" },
+]
 license = 'MIT'
 readme = "README.md"
-repository = 'https://github.com/lidatong/dataclasses-json'
+
+[project.urls]
+Repository = 'https://github.com/lidatong/dataclasses-json'
+Changelog = "https://github.com/lidatong/dataclasses-json/releases"
+Documentation = "https://lidatong.github.io/dataclasses-json/"
+Issues = "https://github.com/lidatong/dataclasses-json/issues"
 
 [tool.poetry.dependencies]
 python = "^3.7"
@@ -32,8 +44,3 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry-dynamic-versioning]
 enable = true
-
-[tool.poetry.urls]
-changelog = "https://github.com/lidatong/dataclasses-json/releases"
-documentation = "https://lidatong.github.io/dataclasses-json/"
-issues = "https://github.com/lidatong/dataclasses-json/issues"


### PR DESCRIPTION
adopted the changes from #553 and added some changes for `project.urls`

closes #553