### PR TITLE
fix marshmallow warning

### DIFF
--- a/dataclasses_json/api.py
+++ b/dataclasses_json/api.py
@@ -103,16 +103,16 @@ class DataClassJsonMixin(abc.ABC):
 
 
 @overload
-def dataclass_json(_cls: None = ..., *, letter_case: Optional[LetterCase] = ...,
+def dataclass_json(_cls: None = ..., *, letter_case: Optional[Union[Callable[[str], str], LetterCase]] = ...,
                    undefined: Optional[Union[str, Undefined]] = ...) -> Callable[[Type[T]], Type[T]]: ...
 
 
 @overload
-def dataclass_json(_cls: Type[T], *, letter_case: Optional[LetterCase] = ...,
+def dataclass_json(_cls: Type[T], *, letter_case: Optional[Union[Callable[[str], str], LetterCase]] = ...,
                    undefined: Optional[Union[str, Undefined]] = ...) -> Type[T]: ...
 
 
-def dataclass_json(_cls: Optional[Type[T]] = None, *, letter_case: Optional[LetterCase] = None,
+def dataclass_json(_cls: Optional[Type[T]] = None, *, letter_case: Optional[Union[Callable[[str], str], LetterCase]] = None,
                    undefined: Optional[Union[str, Undefined]] = None) -> Union[Callable[[Type[T]], Type[T]], Type[T]]:
     """
     Based on the code in the `dataclasses` module to handle optional-parens
@@ -132,7 +132,7 @@ def dataclass_json(_cls: Optional[Type[T]] = None, *, letter_case: Optional[Lett
     return wrap(_cls)
 
 
-def _process_class(cls: Type[T], letter_case: Optional[LetterCase],
+def _process_class(cls: Type[T], letter_case: Optional[Union[Callable[[str], str], LetterCase]],
                    undefined: Optional[Union[str, Undefined]]) -> Type[T]:
     if letter_case is not None or undefined is not None:
         cls.dataclass_json_config = config(letter_case=letter_case,  # type: ignore[attr-defined]

--- a/dataclasses_json/mm.py
+++ b/dataclasses_json/mm.py
@@ -245,9 +245,12 @@ def build_type(type_, options, mixin, field, cls):
 
         if is_dataclass(type_):
             if _issubclass_safe(type_, mixin):
-                options['field_many'] = bool(
-                    _is_supported_generic(field.type) and _is_collection(
-                        field.type))
+                metadata = {
+                    'field_many': bool(
+                        _is_supported_generic(field.type) and _is_collection(
+                            field.type))
+                }
+                options['metadata'] = metadata
                 return fields.Nested(type_.schema(), **options)
             else:
                 warnings.warn(f"Nested dataclass field {field.name} of type "

--- a/dataclasses_json/mm.py
+++ b/dataclasses_json/mm.py
@@ -305,7 +305,7 @@ def schema(cls, mixin, infer_missing):
         else:
             type_ = field.type
             options: typing.Dict[str, typing.Any] = {}
-            missing_key = 'missing' if infer_missing else 'default'
+            missing_key = 'missing' if infer_missing else 'dump_default'
             if field.default is not MISSING:
                 options[missing_key] = field.default
             elif field.default_factory is not MISSING:


### PR DESCRIPTION
Fixed two wanrings in marshmallow:

- Passing field metadata as keyword arguments is deprecated. Use the explicit `metadata=...` argument instead.
- The 'default' argument to fields is deprecated. Use 'dump_default' instead.