### PR TITLE
fix: respect default_factory for abstract generic fields in from_dict

### DIFF
--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -162,12 +162,14 @@ def _decode_dataclass(cls, kvs, infer_missing):
     decode_names = _decode_letter_case_overrides(field_names, overrides)
     kvs = {decode_names.get(k, k): v for k, v in kvs.items()}
     missing_fields = {field for field in fields(cls) if field.name not in kvs}
+    factory_populated_fields = set()
 
     for field in missing_fields:
         if field.default is not MISSING:
             kvs[field.name] = field.default
         elif field.default_factory is not MISSING:
             kvs[field.name] = field.default_factory()
+            factory_populated_fields.add(field.name)
         elif infer_missing:
             kvs[field.name] = None
 
@@ -230,9 +232,12 @@ def _decode_dataclass(cls, kvs, infer_missing):
                                           infer_missing)
             init_kwargs[field.name] = value
         elif _is_supported_generic(field_type) and field_type != str:
-            init_kwargs[field.name] = _decode_generic(field_type,
-                                                      field_value,
-                                                      infer_missing)
+            if field.name in factory_populated_fields:
+                init_kwargs[field.name] = field_value
+            else:
+                init_kwargs[field.name] = _decode_generic(field_type,
+                                                          field_value,
+                                                          infer_missing)
         else:
             init_kwargs[field.name] = _support_extended_types(field_type,
                                                               field_value)

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -264,3 +264,23 @@ class TestDecoder:
     )
     def test_abstract_collections(self, json_string, expected_instance):
         assert type(expected_instance).from_json(json_string) == expected_instance
+
+    def test_mutable_mapping_default_factory_from_empty_dict(self):
+        """Regression test for issue #505:
+        MutableMapping fields with default_factory should not raise TypeError
+        when deserializing from an input dict that omits the field."""
+        from collections.abc import MutableMapping
+        from dataclasses import dataclass, field
+        from dataclasses_json import DataClassJsonMixin
+
+        @dataclass
+        class MyClass(DataClassJsonMixin):
+            field1: MutableMapping[str, str] = field(default_factory=dict)
+
+        # Should not raise TypeError: MutableMapping() takes no arguments
+        result = MyClass.from_dict({})
+        assert result.field1 == {}
+
+        # Full round-trip should also work
+        obj = MyClass(field1={"key": "value"})
+        assert MyClass.from_dict(obj.to_dict()).field1 == {"key": "value"}


### PR DESCRIPTION
## Problem

When a dataclass field is typed as an abstract generic collection (e.g. `MutableMapping[str, str]`) and given a `default_factory`, calling `from_dict({})` raises `TypeError: MutableMapping() takes no arguments`.

Fixes #505.

## Root cause

In `_decode_dataclass`, fields missing from the input dict are correctly populated via `default_factory()`. However, the subsequent decoding loop still calls `_decode_generic` on that already-correct value, which attempts to instantiate the abstract `MutableMapping` type directly.

## Fix

Track which fields were populated by `default_factory` (as opposed to arriving from the input data). In the decode loop, skip `_decode_generic` for those fields and pass the factory-produced value through as-is.

## Test

Added a regression test in `tests/test_collections.py` covering both the empty-dict case and a full round-trip:

\`\`\`python
@dataclass
class MyClass(DataClassJsonMixin):
    field1: MutableMapping[str, str] = field(default_factory=dict)

MyClass.from_dict({})  # previously raised TypeError
MyClass.from_dict(MyClass(field1={"key": "value"}).to_dict())  # round-trip
\`\`\`

Full test suite: **323 passed, 4 skipped, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)