### PR TITLE
fix: run tests on ubuntu-22.04 to support python3.7

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -2,19 +2,19 @@ name: test-and-release
 
 on:
   push:
-    branches: 
+    branches:
       - master
       - release/*  # this is a backup. prefer publishing using a tagged master.
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
   pull_request:
-    branches: 
+    branches:
       - master
   workflow_dispatch:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04  # instead of ubuntu-latest to support python3.7
     strategy:
       max-parallel: 5
       matrix:
@@ -41,7 +41,7 @@ jobs:
         else
           curl -sSL https://install.python-poetry.org | python3 -
         fi
-        
+
         poetry install --all-extras
     - name: Lint with flake8
       run: |
@@ -49,10 +49,10 @@ jobs:
         poetry run flake8 dataclasses_json --show-source --statistics --count
     - name: Test with pytest
       run: |
-        set -euxo pipefail    
-        
+        set -euxo pipefail
+
         poetry run pytest ./tests --doctest-modules --junitxml=junit/test-results.xml --cov=. --cov-report=term-missing:skip-covered | tee pytest-coverage.txt
-        
+
     - name: Publish Code Coverage
       uses: MishaKav/pytest-coverage-comment@main
       if: ${{ !github.event.pull_request.head.repo.fork }}
@@ -77,13 +77,13 @@ jobs:
       - name: Install Poetry and Prepare version
         run: |
           set -e
-          
+
           curl -sSL https://install.python-poetry.org | python3 -
           poetry self add "poetry-dynamic-versioning[plugin]"
       - name: Build package
         run: |
           set -e
-        
+
           poetry build
 
       - name: Publish distribution 📦 to Test PyPI


### PR DESCRIPTION
## changes

ubuntu-latest (24.04) does not support python3.7,
see https://github.com/actions/python-versions/blob/d75b46f6585cbd8749cc6cff669100a406746964/versions-manifest.json#L13066-L13092

from https://github.com/lidatong/dataclasses-json/actions/runs/25035565345/job/73326350509?pr=571:

```
Error: The version '3.7' with architecture 'x64' was not found for Ubuntu 24.04.
```

## test

ran `test-and-release` workflow through `workflow_dispatch`:
https://github.com/lidatong/dataclasses-json/actions/runs/25037875440

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>