### PR TITLE
Keep digits attached to preceding letter in SNAKE letter case

### DIFF
--- a/dataclasses_json/stringcase.py
+++ b/dataclasses_json/stringcase.py
@@ -96,7 +96,7 @@ def snakecase(string):
     if not string:
         return string
     return (uplowcase(string[0], 'low')
-            + re.sub(r"[A-Z0-9]",
+            + re.sub(r"[A-Z]",
                      lambda matched: '_' + uplowcase(matched.group(0), 'low'),
                      string[1:]))
 

--- a/tests/test_letter_case.py
+++ b/tests/test_letter_case.py
@@ -37,6 +37,16 @@ class SnakeCasePerson:
 
 @dataclass_json
 @dataclass
+class SnakeCaseNumberedPerson:
+    cardsV2: str = field(
+        metadata={'dataclasses_json': {
+            'letter_case': LetterCase.SNAKE
+        }}
+    )
+
+
+@dataclass_json
+@dataclass
 class PascalCasePerson:
     given_name: str = field(
         metadata={'dataclasses_json': {
@@ -104,6 +114,9 @@ class TestLetterCase:
     def test_snake_decode(self):
         assert SnakeCasePerson.from_json(
             '{"given_name": "Alice"}') == SnakeCasePerson('Alice')
+
+    def test_snake_encode_keeps_digit_with_preceding_letter(self):
+        assert SnakeCaseNumberedPerson('card').to_json() == '{"cards_v2": "card"}'
 
     def test_pascal_encode(self):
         assert PascalCasePerson('Alice').to_json() == '{"GivenName": "Alice"}'


### PR DESCRIPTION
`LetterCase.SNAKE` inserts an underscore before every digit, so a field like `cardsV2` serializes to `cards_v_2` instead of `cards_v2`. This reverts `snakecase` to split only on uppercase letters, matching the original vendored `stringcase` behavior. Closes #555.